### PR TITLE
Add endpoint listing TA4J strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Création d'une API Java Spring capable de traiter des données financières et 
       - L'entrée de données doit exister dans la base de données pour être supprimée.
       - La suppression doit être irréversible et l'utilisateur doit être informé des conséquences.
 
+13. **Liste des Stratégies TA4J (GET /strategies)**
+    - **Description** : Retourne l'ensemble des stratégies disponibles dans le package `ta4j`.
+    - **Règles Business** :
+      - La liste doit être générée dynamiquement en fonction des stratégies présentes dans l'application.
+
 ## Fonctionnalités Avancées (Long Terme)
 
 1. Ajout de Nouvelles Sources de Données

--- a/src/main/java/finance/project/api/controllers/StrategyController.java
+++ b/src/main/java/finance/project/api/controllers/StrategyController.java
@@ -1,0 +1,32 @@
+package finance.project.api.controllers;
+
+import finance.project.api.services.StrategyDiscoveryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+/**
+ * REST controller exposing the list of available TA4J strategies.
+ */
+@Controller
+public class StrategyController {
+
+    private final StrategyDiscoveryService strategyDiscoveryService;
+
+    public StrategyController(StrategyDiscoveryService strategyDiscoveryService) {
+        this.strategyDiscoveryService = strategyDiscoveryService;
+    }
+
+    /**
+     * Returns the simple class names of all strategies located in
+     * {@code finance.project.api.strategies.ta4j}.
+     *
+     * @return list of strategy names
+     */
+    @GetMapping("/strategies")
+    public ResponseEntity<List<String>> listStrategies() {
+        return ResponseEntity.ok(strategyDiscoveryService.getAvailableStrategies());
+    }
+}

--- a/src/main/java/finance/project/api/services/StrategyDiscoveryService.java
+++ b/src/main/java/finance/project/api/services/StrategyDiscoveryService.java
@@ -1,0 +1,42 @@
+package finance.project.api.services;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility service that scans the classpath for strategy classes located in the
+ * "finance.project.api.strategies.ta4j" package. It returns their simple class
+ * names so they can be exposed through an API endpoint.
+ */
+@Service
+public class StrategyDiscoveryService {
+    private static final String STRATEGIES_PACKAGE = "finance.project.api.strategies.ta4j";
+
+    /**
+     * Scans the predefined strategies package and returns all strategy class names.
+     *
+     * @return list of available strategy names
+     */
+    public List<String> getAvailableStrategies() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AssignableTypeFilter(Object.class));
+
+        Set<BeanDefinition> components = scanner.findCandidateComponents(STRATEGIES_PACKAGE);
+        List<String> names = new ArrayList<>();
+        for (BeanDefinition bd : components) {
+            String className = bd.getBeanClassName();
+            if (className != null) {
+                int idx = className.lastIndexOf('.');
+                names.add(className.substring(idx + 1));
+            }
+        }
+        return names;
+    }
+}


### PR DESCRIPTION
## Summary
- add `StrategyDiscoveryService` to dynamically scan the `ta4j` package
- expose `/strategies` endpoint via new `StrategyController`
- document the endpoint in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686970a6525c8323be6ecb3c8fdf3ea2