### PR TITLE
Add generic TA4J strategy endpoint

### DIFF
--- a/src/main/java/finance/project/api/controllers/BacktestController.java
+++ b/src/main/java/finance/project/api/controllers/BacktestController.java
@@ -122,6 +122,32 @@ public class BacktestController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/run-strategy-by-name")
+    public ResponseEntity<StrategyResult> runStrategyByName(
+            @RequestParam String strategyName,
+            @RequestParam String symbol,
+            @RequestParam String timeframe,
+            @RequestParam(defaultValue = "1000") int period,
+            @RequestParam(required = false) String comparedSymbol,
+            @RequestParam(required = false) Double slPercent,
+            @RequestParam(required = false) Double rrRatio,
+            @RequestParam(required = false) Double explosionPct,
+            @RequestParam(required = false) Double stepPct) {
+
+        candleCacheManager.preload(symbol, timeframe, period);
+        StrategyResult result = strategyManager.runStrategyByName(strategyName, symbol, timeframe, period,
+                slPercent, rrRatio, explosionPct, stepPct);
+
+        tradeService.saveTrades(strategyName, result.getSignals());
+        String runId = UUID.randomUUID().toString();
+        tradeCompletedService.saveCompletedTrades(strategyName, result.getCompletedTrades(), runId);
+
+        String compared = comparedSymbol != null ? comparedSymbol : symbol;
+        performanceService.savePerformance(strategyName, runId, result.getPerformance(), symbol, compared);
+
+        return ResponseEntity.ok(result);
+    }
+
     @GetMapping("/all-strategies")
     public ResponseEntity<List<PerfsStratsDTO>> getAllCalculatedStrategies() {
         return ResponseEntity.ok(performanceService.getAllStrategyPerformances());

--- a/src/main/java/finance/project/api/strategies/StrategyManager.java
+++ b/src/main/java/finance/project/api/strategies/StrategyManager.java
@@ -70,6 +70,28 @@ public class StrategyManager {
         return macdPredictionStrategy.execute(symbol, timeframe, period, rrRatio);
     }
 
+    public StrategyResult runStrategyByName(String strategyName, String symbol, String timeframe, int period,
+                                            Double slPercent, Double rrRatio,
+                                            Double explosionPct, Double stepPct) {
+        switch (strategyName.toLowerCase()) {
+            case "trendfollowing" -> {
+                double sl = slPercent != null ? slPercent : 1.0;
+                double rr = rrRatio != null ? rrRatio : 2.0;
+                return runTrendFollowing(symbol, timeframe, period, sl, rr);
+            }
+            case "explosiongrid" -> {
+                double exp = explosionPct != null ? explosionPct : 2.0;
+                double step = stepPct != null ? stepPct : 5.0;
+                return runExplosionGrid(symbol, timeframe, period, exp, step);
+            }
+            case "macdprediction" -> {
+                double rr = rrRatio != null ? rrRatio : 2.0;
+                return runMacdPrediction(symbol, timeframe, period, rr);
+            }
+            default -> throw new IllegalArgumentException("Unknown strategy: " + strategyName);
+        }
+    }
+
     /*
     public void runStrategies() {
         List<BaseStrategy> enabledStrategies = allStrategies.stream()


### PR DESCRIPTION
## Summary
- extend `StrategyManager` with helper to run a strategy by its name
- add `/run-strategy-by-name` endpoint in `BacktestController`

## Testing
- `./mvnw -q test` *(fails: Could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6869701527fc83239e563ce057e8b488