### PR TITLE
Add Binance range query endpoint

### DIFF
--- a/src/main/java/finance/project/api/controllers/CandleController.java
+++ b/src/main/java/finance/project/api/controllers/CandleController.java
@@ -314,4 +314,16 @@ public class CandleController {
         return new ResponseEntity<>(candles, HttpStatus.OK);
     }
 
+    @GetMapping("/binance/historical-range")
+    public ResponseEntity<List<CandleDTO>> loadBinanceHistoricalRange(
+            @RequestParam String symbol,
+            @RequestParam String interval,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate) {
+
+        List<CandleDTO> candles = binanceService.getHistoricalCandlesInRange(symbol, interval, startDate, endDate);
+        candleService.saveCandlesToDatabase(candles, symbol, interval);
+        return new ResponseEntity<>(candles, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/finance/project/api/services/BinanceService.java
+++ b/src/main/java/finance/project/api/services/BinanceService.java
@@ -74,4 +74,57 @@ public class BinanceService {
         }
         return candles;
     }
+
+    /**
+     * Retrieve historical candles from Binance for a specific time range.
+     *
+     * @param symbol    trading pair (e.g. BTCUSDT)
+     * @param interval  candle interval (e.g. 1h,4h,1d)
+     * @param startDate start of the range in UTC
+     * @param endDate   end of the range in UTC
+     * @return list of CandleDTO
+     */
+    public List<CandleDTO> getHistoricalCandlesInRange(String symbol, String interval,
+                                                       LocalDateTime startDate, LocalDateTime endDate) {
+        String url = UriComponentsBuilder.fromHttpUrl(binanceApiUrl + "/klines")
+                .queryParam("symbol", symbol)
+                .queryParam("interval", interval)
+                .queryParam("startTime", startDate.toInstant(ZoneOffset.UTC).toEpochMilli())
+                .queryParam("endTime", endDate.toInstant(ZoneOffset.UTC).toEpochMilli())
+                .toUriString();
+
+        ResponseEntity<List<List<Object>>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        List<List<Object>> body = response.getBody();
+        if (body == null) {
+            return List.of();
+        }
+
+        List<CandleDTO> candles = new ArrayList<>();
+        for (List<Object> entry : body) {
+            long openTime = ((Number) entry.get(0)).longValue();
+            String open = entry.get(1).toString();
+            String high = entry.get(2).toString();
+            String low = entry.get(3).toString();
+            String close = entry.get(4).toString();
+            String volume = entry.get(5).toString();
+
+            candles.add(CandleDTO.builder()
+                    .date(LocalDateTime.ofInstant(Instant.ofEpochMilli(openTime), ZoneOffset.UTC))
+                    .open(new BigDecimal(open))
+                    .high(new BigDecimal(high))
+                    .low(new BigDecimal(low))
+                    .close(new BigDecimal(close))
+                    .volume(new BigDecimal(volume))
+                    .symbol(SymbolDTO.builder().symbol(symbol).build())
+                    .timeframe(interval)
+                    .build());
+        }
+        return candles;
+    }
 }


### PR DESCRIPTION
## Summary
- extend BinanceService to support fetching candles in a custom time range
- expose `/api/finance/charts/binance/historical-range` endpoint

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a6c897b048323a1d4d545aa60ad69