### PR TITLE
Add IBKR portfolio snapshot endpoint

### DIFF
--- a/src/main/java/finance/project/api/controllers/IbkrController.java
+++ b/src/main/java/finance/project/api/controllers/IbkrController.java
@@ -9,6 +9,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 @RestController
 @RequestMapping("/ibkr")
@@ -177,14 +179,24 @@ public class IbkrController {
             @RequestParam(required = false) String account,
             @RequestParam(defaultValue = "5000") long timeoutMs
     ) {
-        ensureConnected();
         if (!"IBKR".equalsIgnoreCase(broker)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported broker: " + broker);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Broker non supporté: " + broker);
         }
+        ensureConnected();
         try {
-            return ib.fetchPortfolioSnapshot(account, timeoutMs);
-        } catch (RuntimeException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "IBKR portfolio retrieval failed: " + e.getMessage(), e);
+            return ib.getPortfolioSnapshot(account, timeoutMs);
+        } catch (TimeoutException e) {
+            throw new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, "IBKR portfolio timeout: " + e.getMessage(), e);
+        } catch (ExecutionException e) {
+            Throwable root = e.getCause() != null ? e.getCause() : e;
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "IBKR portfolio error: " + root.getMessage(), root);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Thread interrupted", e);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+        } catch (IllegalStateException e) {
+            throw new ResponseStatusException(HttpStatus.PRECONDITION_FAILED, e.getMessage(), e);
         }
     }
 

--- a/src/main/java/finance/project/api/controllers/IbkrController.java
+++ b/src/main/java/finance/project/api/controllers/IbkrController.java
@@ -171,6 +171,23 @@ public class IbkrController {
         }
     }
 
+    @GetMapping("/portfolio")
+    public IbkrFxService.PortfolioSnapshot getPortfolio(
+            @RequestParam(defaultValue = "IBKR") String broker,
+            @RequestParam(required = false) String account,
+            @RequestParam(defaultValue = "5000") long timeoutMs
+    ) {
+        ensureConnected();
+        if (!"IBKR".equalsIgnoreCase(broker)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported broker: " + broker);
+        }
+        try {
+            return ib.fetchPortfolioSnapshot(account, timeoutMs);
+        } catch (RuntimeException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "IBKR portfolio retrieval failed: " + e.getMessage(), e);
+        }
+    }
+
     // --- Helper ---
     private void ensureConnected() {
         if (!ib.isConnected()) {

--- a/src/main/java/finance/project/api/services/IbkrFxService.java
+++ b/src/main/java/finance/project/api/services/IbkrFxService.java
@@ -45,6 +45,9 @@ public class IbkrFxService extends IbkrWrapperAdapter {
     private final ConcurrentHashMap<Integer, CompletableFuture<List<HistBar>>> histFutures = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, List<HistBar>> histBuffers = new ConcurrentHashMap<>();
 
+    private final Object portfolioLock = new Object();
+    private volatile PortfolioRequest currentPortfolioRequest;
+
     private static final java.util.regex.Pattern MULTISPACE = java.util.regex.Pattern.compile("\\s+");
     private static final java.time.format.DateTimeFormatter F_NO_TZ =
             java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd HH:mm:ss");
@@ -317,6 +320,27 @@ public class IbkrFxService extends IbkrWrapperAdapter {
 
     public record FxQuote(long tsMillis, double bid, double ask) { }
     public record HistBar(long tsMillis, double open, double high, double low, double close, long volume) { }
+    public record PortfolioSnapshot(
+            String account,
+            String currency,
+            double availableFunds,
+            double netLiquidation,
+            double grossPositionValue,
+            double totalPositionsValue,
+            List<PositionBreakdown> positions
+    ) { }
+
+    public record PositionBreakdown(
+            long conid,
+            String symbol,
+            String localSymbol,
+            String securityType,
+            String currency,
+            double position,
+            double marketPrice,
+            double marketValue,
+            double allocation
+    ) { }
 
     /** ----------- EWrapper (callbacks) ----------- */
 
@@ -380,6 +404,250 @@ public class IbkrFxService extends IbkrWrapperAdapter {
             // Tri chrono si nécessaire (IB envoie souvent déjà trié)
             buf.sort(Comparator.comparingLong(HistBar::tsMillis));
             fut.complete(buf);
+        }
+    }
+
+    /** ----------- ACCOUNT / PORTFOLIO ----------- */
+
+    public PortfolioSnapshot fetchPortfolioSnapshot(String account) {
+        return fetchPortfolioSnapshot(account, 5000);
+    }
+
+    public PortfolioSnapshot fetchPortfolioSnapshot(String account, long timeoutMs) {
+        if (!client.isConnected()) {
+            throw new IllegalStateException("Not connected to TWS/IB Gateway");
+        }
+        long effectiveTimeout = timeoutMs <= 0 ? 5000 : timeoutMs;
+        PortfolioRequest request = new PortfolioRequest(account);
+        synchronized (portfolioLock) {
+            if (currentPortfolioRequest != null) {
+                throw new IllegalStateException("Another portfolio request is already in progress");
+            }
+            currentPortfolioRequest = request;
+        }
+
+        try {
+            client.reqAccountUpdates(true, request.requestedAccount());
+            return request.future().get(effectiveTimeout, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            request.markCompleted();
+            request.future().completeExceptionally(e);
+            throw new RuntimeException("Interrupted while waiting for IBKR portfolio", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            request.markCompleted();
+            throw new RuntimeException("Failed to fetch IBKR portfolio: " + cause.getMessage(), cause);
+        } catch (TimeoutException e) {
+            request.markCompleted();
+            request.future().completeExceptionally(e);
+            throw new RuntimeException("Timed out waiting for IBKR portfolio", e);
+        } finally {
+            try {
+                client.reqAccountUpdates(false, request.requestedAccount());
+            } catch (Exception ignored) {
+            }
+            synchronized (portfolioLock) {
+                currentPortfolioRequest = null;
+            }
+        }
+    }
+
+    @Override
+    public void updateAccountValue(String key, String value, String currency, String accountName) {
+        PortfolioRequest request = currentPortfolioRequest;
+        if (request == null || !request.matchesAccount(accountName)) return;
+        if (value == null || value.isBlank()) return;
+        try {
+            double numericValue = Double.parseDouble(value);
+            request.setCurrencyIfAbsent(currency);
+            switch (key) {
+                case "AvailableFunds" -> request.setAvailableFunds(numericValue);
+                case "NetLiquidation" -> request.setNetLiquidation(numericValue);
+                case "GrossPositionValue" -> request.setGrossPositionValue(numericValue);
+                default -> {
+                }
+            }
+        } catch (NumberFormatException ignored) {
+        }
+    }
+
+    @Override
+    public void updatePortfolio(Contract contract, double position, double marketPrice, double marketValue,
+                                double averageCost, double unrealizedPNL, double realizedPNL, String accountName) {
+        PortfolioRequest request = currentPortfolioRequest;
+        if (request == null || !request.matchesAccount(accountName)) return;
+        String key = positionKey(contract);
+        PortfolioPositionAccumulator accumulator = request.positions().computeIfAbsent(key, k -> new PortfolioPositionAccumulator(contract));
+        accumulator.position = position;
+        accumulator.marketPrice = marketPrice;
+        accumulator.marketValue = marketValue;
+        accumulator.averageCost = averageCost;
+        accumulator.unrealizedPnl = unrealizedPNL;
+        accumulator.realizedPnl = realizedPNL;
+    }
+
+    @Override
+    public void accountDownloadEnd(String accountName) {
+        PortfolioRequest request = currentPortfolioRequest;
+        if (request == null || !request.matchesAccount(accountName) || request.future().isDone()) return;
+
+        double totalPositionsValue = request.positions().values().stream()
+                .mapToDouble(p -> Math.abs(p.marketValue))
+                .sum();
+
+        List<PositionBreakdown> positions = request.positions().values().stream()
+                .sorted(Comparator.comparingDouble((PortfolioPositionAccumulator p) -> Math.abs(p.marketValue)).reversed())
+                .map(acc -> toPositionBreakdown(acc, totalPositionsValue))
+                .toList();
+
+        double grossPositionValue = Double.isNaN(request.grossPositionValue()) ? totalPositionsValue : request.grossPositionValue();
+
+        PortfolioSnapshot snapshot = new PortfolioSnapshot(
+                request.effectiveAccount(),
+                request.currency(),
+                sanitizeDouble(request.availableFunds()),
+                sanitizeDouble(request.netLiquidation()),
+                sanitizeDouble(grossPositionValue),
+                totalPositionsValue,
+                positions
+        );
+
+        request.markCompleted();
+        request.future().complete(snapshot);
+    }
+
+    private double sanitizeDouble(double value) {
+        return Double.isFinite(value) ? value : 0.0;
+    }
+
+    private PositionBreakdown toPositionBreakdown(PortfolioPositionAccumulator acc, double totalPositionsValue) {
+        Contract contract = acc.contract;
+        double allocation = totalPositionsValue == 0.0 ? 0.0 : Math.abs(acc.marketValue) / totalPositionsValue;
+        return new PositionBreakdown(
+                contract != null ? contract.conid() : 0,
+                contract != null ? nullToEmpty(contract.symbol()) : "",
+                contract != null ? nullToEmpty(contract.localSymbol()) : "",
+                contract != null ? nullToEmpty(contract.secType()) : "",
+                contract != null ? nullToEmpty(contract.currency()) : "",
+                acc.position,
+                acc.marketPrice,
+                acc.marketValue,
+                allocation
+        );
+    }
+
+    private String nullToEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private String positionKey(Contract contract) {
+        if (contract == null) return "UNKNOWN";
+        int conid = contract.conid();
+        if (conid != 0) {
+            return "CONID:" + conid;
+        }
+        return (nullToEmpty(contract.symbol()) + ':' + nullToEmpty(contract.secType()) + ':' + nullToEmpty(contract.currency()) + ':' + nullToEmpty(contract.exchange())).toUpperCase(Locale.ROOT);
+    }
+
+    private static class PortfolioRequest {
+        private final String requestedAccount;
+        private final CompletableFuture<PortfolioSnapshot> future = new CompletableFuture<>();
+        private final Map<String, PortfolioPositionAccumulator> positions = new LinkedHashMap<>();
+        private volatile double availableFunds = Double.NaN;
+        private volatile double netLiquidation = Double.NaN;
+        private volatile double grossPositionValue = Double.NaN;
+        private volatile String currency;
+        private volatile String effectiveAccount;
+        private volatile boolean completed;
+
+        PortfolioRequest(String requestedAccount) {
+            this.requestedAccount = requestedAccount == null ? "" : requestedAccount.trim();
+        }
+
+        String requestedAccount() {
+            return requestedAccount;
+        }
+
+        CompletableFuture<PortfolioSnapshot> future() {
+            return future;
+        }
+
+        Map<String, PortfolioPositionAccumulator> positions() {
+            return positions;
+        }
+
+        double availableFunds() {
+            return availableFunds;
+        }
+
+        double netLiquidation() {
+            return netLiquidation;
+        }
+
+        double grossPositionValue() {
+            return grossPositionValue;
+        }
+
+        String currency() {
+            return currency;
+        }
+
+        String effectiveAccount() {
+            return effectiveAccount == null ? requestedAccount : effectiveAccount;
+        }
+
+        boolean matchesAccount(String accountName) {
+            if (completed) return false;
+            if (accountName == null || accountName.isBlank()) {
+                return requestedAccount.isBlank() || Objects.equals(effectiveAccount, accountName);
+            }
+            if (!requestedAccount.isBlank() && !requestedAccount.equals(accountName)) {
+                return false;
+            }
+            if (effectiveAccount != null && !effectiveAccount.equals(accountName)) {
+                return false;
+            }
+            if (effectiveAccount == null) {
+                effectiveAccount = accountName;
+            }
+            return true;
+        }
+
+        void setCurrencyIfAbsent(String newCurrency) {
+            if (this.currency == null && newCurrency != null && !newCurrency.isBlank()) {
+                this.currency = newCurrency;
+            }
+        }
+
+        void setAvailableFunds(double value) {
+            this.availableFunds = value;
+        }
+
+        void setNetLiquidation(double value) {
+            this.netLiquidation = value;
+        }
+
+        void setGrossPositionValue(double value) {
+            this.grossPositionValue = value;
+        }
+
+        void markCompleted() {
+            this.completed = true;
+        }
+    }
+
+    private static class PortfolioPositionAccumulator {
+        final Contract contract;
+        double position;
+        double marketPrice;
+        double marketValue;
+        double averageCost;
+        double unrealizedPnl;
+        double realizedPnl;
+
+        PortfolioPositionAccumulator(Contract contract) {
+            this.contract = contract;
         }
     }
 

--- a/src/main/java/finance/project/api/services/IbkrFxService.java
+++ b/src/main/java/finance/project/api/services/IbkrFxService.java
@@ -12,6 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import com.ib.client.EWrapper;
 import com.ib.client.TickType;
@@ -46,7 +47,7 @@ public class IbkrFxService extends IbkrWrapperAdapter {
     private final ConcurrentHashMap<Integer, List<HistBar>> histBuffers = new ConcurrentHashMap<>();
 
     private final Object portfolioLock = new Object();
-    private volatile PortfolioRequest currentPortfolioRequest;
+    private volatile PortfolioSnapshotRequest activePortfolioRequest;
 
     private static final java.util.regex.Pattern MULTISPACE = java.util.regex.Pattern.compile("\\s+");
     private static final java.time.format.DateTimeFormatter F_NO_TZ =
@@ -305,6 +306,54 @@ public class IbkrFxService extends IbkrWrapperAdapter {
         return fut.get(30, TimeUnit.SECONDS);
     }
 
+    /** ----------- PORTEFEUILLE / ACCOUNT SNAPSHOT ----------- */
+
+    public PortfolioSnapshot getPortfolioSnapshot(String account, long timeoutMs)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        if (timeoutMs <= 0) {
+            throw new IllegalArgumentException("timeoutMs doit être strictement positif");
+        }
+        if (!client.isConnected()) {
+            throw new IllegalStateException("Not connected to TWS/IB Gateway");
+        }
+
+        String accountCode = account == null ? "" : account.trim();
+        if ("null".equalsIgnoreCase(accountCode)) {
+            accountCode = "";
+        }
+
+        PortfolioSnapshotRequest request = new PortfolioSnapshotRequest(accountCode.isEmpty() ? null : accountCode);
+        synchronized (portfolioLock) {
+            if (activePortfolioRequest != null) {
+                throw new IllegalStateException("Une requête de portefeuille est déjà en cours");
+            }
+            activePortfolioRequest = request;
+        }
+
+        boolean started = false;
+        try {
+            client.reqAccountUpdates(true, accountCode);
+            started = true;
+            return request.future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            request.fail(e);
+            throw e;
+        } catch (TimeoutException | ExecutionException e) {
+            request.fail(e);
+            throw e;
+        } finally {
+            if (started) {
+                client.reqAccountUpdates(false, accountCode);
+            }
+            synchronized (portfolioLock) {
+                if (activePortfolioRequest == request) {
+                    activePortfolioRequest = null;
+                }
+            }
+        }
+    }
+
     /** ----------- CONTRAT FX EURUSD ----------- */
 
     private Contract eurUsdCash() {
@@ -320,29 +369,287 @@ public class IbkrFxService extends IbkrWrapperAdapter {
 
     public record FxQuote(long tsMillis, double bid, double ask) { }
     public record HistBar(long tsMillis, double open, double high, double low, double close, long volume) { }
-    public record PortfolioSnapshot(
-            String account,
-            String currency,
-            double availableFunds,
-            double netLiquidation,
-            double grossPositionValue,
-            double totalPositionsValue,
-            List<PositionBreakdown> positions
-    ) { }
+    public record MoneyValue(double amount, String currency) { }
+    public record PositionAllocation(String account, String symbol, String description,
+                                     String securityType, String currency, double quantity,
+                                     double marketPrice, double marketValue, double relativeShare) { }
+    public record PortfolioSnapshot(String account, long asOfEpochMillis,
+                                    MoneyValue availableLiquidity,
+                                    MoneyValue netLiquidation,
+                                    List<PositionAllocation> positions) { }
 
-    public record PositionBreakdown(
-            long conid,
-            String symbol,
-            String localSymbol,
-            String securityType,
-            String currency,
-            double position,
-            double marketPrice,
-            double marketValue,
-            double allocation
-    ) { }
+    private static final class PositionData {
+        String account;
+        final String symbol;
+        final String description;
+        final String securityType;
+        final String currency;
+        double position;
+        double marketPrice;
+        double marketValue;
+
+        PositionData(String account, Contract contract) {
+            this.account = account != null && !account.isBlank() ? account : null;
+            if (contract != null) {
+                this.symbol = safeOrFallback(contract.localSymbol(), contract.symbol());
+                this.description = describeContract(contract);
+                this.securityType = safe(contract.secType());
+                this.currency = safe(contract.currency());
+            } else {
+                this.symbol = "";
+                this.description = "";
+                this.securityType = "";
+                this.currency = "";
+            }
+        }
+    }
+
+    private static final class PortfolioSnapshotRequest {
+        final String requestedAccount;
+        final CompletableFuture<PortfolioSnapshot> future = new CompletableFuture<>();
+        final Map<String, Double> availableFunds = new HashMap<>();
+        final Map<String, Double> cashBalances = new HashMap<>();
+        final Map<String, Double> netLiquidation = new HashMap<>();
+        final Map<String, PositionData> positions = new LinkedHashMap<>();
+        boolean completed;
+        String accountName;
+
+        PortfolioSnapshotRequest(String requestedAccount) {
+            this.requestedAccount = requestedAccount;
+        }
+
+        boolean matchesAccount(String account) {
+            if (requestedAccount == null || requestedAccount.isBlank()) {
+                return true;
+            }
+            if (account == null) {
+                return false;
+            }
+            return requestedAccount.equalsIgnoreCase(account.trim());
+        }
+
+        void recordAccountName(String account) {
+            if (account != null && !account.isBlank()) {
+                this.accountName = account;
+            }
+        }
+
+        void putAvailableFunds(String currency, double value) {
+            availableFunds.put(currency, value);
+        }
+
+        void putCashBalance(String currency, double value) {
+            cashBalances.put(currency, value);
+        }
+
+        void putNetLiquidation(String currency, double value) {
+            netLiquidation.put(currency, value);
+        }
+
+        void fail(Throwable error) {
+            synchronized (this) {
+                if (completed) {
+                    return;
+                }
+                completed = true;
+                future.completeExceptionally(error);
+            }
+        }
+
+        void complete(PortfolioSnapshot snapshot) {
+            synchronized (this) {
+                if (completed) {
+                    return;
+                }
+                completed = true;
+                future.complete(snapshot);
+            }
+        }
+    }
+
+    private void completePortfolioSnapshot(PortfolioSnapshotRequest request) {
+        MoneyValue available = resolveMoneyValue(request.availableFunds, request.cashBalances);
+        MoneyValue net = resolveMoneyValue(request.netLiquidation, Collections.emptyMap());
+
+        double denominator = request.positions.values().stream()
+                .mapToDouble(p -> Math.abs(p.marketValue))
+                .sum();
+
+        List<PositionAllocation> allocations = request.positions.values().stream()
+                .filter(p -> Math.abs(p.position) > 1e-8 || Math.abs(p.marketValue) > 1e-8)
+                .map(p -> new PositionAllocation(
+                        coalesce(p.account, request.accountName, request.requestedAccount),
+                        p.symbol,
+                        p.description,
+                        p.securityType,
+                        p.currency,
+                        p.position,
+                        p.marketPrice,
+                        p.marketValue,
+                        denominator > 0 ? Math.abs(p.marketValue) / denominator : 0d
+                ))
+                .sorted(Comparator.comparingDouble(PositionAllocation::relativeShare).reversed())
+                .collect(Collectors.toList());
+
+        String accountName = coalesce(request.accountName, request.requestedAccount);
+        long asOf = System.currentTimeMillis();
+        PortfolioSnapshot snapshot = new PortfolioSnapshot(accountName, asOf, available, net,
+                Collections.unmodifiableList(allocations));
+        request.complete(snapshot);
+    }
+
+    private static MoneyValue resolveMoneyValue(Map<String, Double> primary, Map<String, Double> fallback) {
+        if (!primary.isEmpty()) {
+            String currency = pickCurrency(primary);
+            return new MoneyValue(primary.get(currency), currency);
+        }
+        if (!fallback.isEmpty()) {
+            String currency = pickCurrency(fallback);
+            return new MoneyValue(fallback.get(currency), currency);
+        }
+        return new MoneyValue(0d, "");
+    }
+
+    private static String pickCurrency(Map<String, Double> values) {
+        if (values.containsKey("BASE")) {
+            return "BASE";
+        }
+        if (values.containsKey("USD")) {
+            return "USD";
+        }
+        return values.keySet().iterator().next();
+    }
+
+    private static String normalizeCurrency(String currency) {
+        if (currency == null || currency.isBlank()) {
+            return "BASE";
+        }
+        return currency.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static String safeOrFallback(String primary, String fallback) {
+        if (primary != null && !primary.isBlank()) {
+            return primary;
+        }
+        return fallback != null ? fallback : "";
+    }
+
+    private static String describeContract(Contract contract) {
+        if (contract == null) {
+            return "";
+        }
+        String local = contract.localSymbol();
+        if (local != null && !local.isBlank()) {
+            return local;
+        }
+        String tradingClass = contract.tradingClass();
+        if (tradingClass != null && !tradingClass.isBlank()) {
+            return tradingClass;
+        }
+        String symbol = contract.symbol();
+        String exchange = contract.exchange();
+        if (symbol != null && !symbol.isBlank() && exchange != null && !exchange.isBlank()) {
+            return symbol + "@" + exchange;
+        }
+        return symbol != null ? symbol : "";
+    }
+
+    private static String coalesce(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String portfolioKey(Contract contract) {
+        if (contract == null) {
+            return UUID.randomUUID().toString();
+        }
+        int conId = contract.conid();
+        if (conId != 0) {
+            return Integer.toString(conId);
+        }
+        return safe(contract.symbol()) + "|" + safe(contract.secType()) + "|" +
+                safe(contract.currency()) + "|" + safe(contract.exchange()) + "|" +
+                safe(contract.localSymbol());
+    }
 
     /** ----------- EWrapper (callbacks) ----------- */
+
+    @Override
+    public void updateAccountValue(String key, String value, String currency, String accountName) {
+        PortfolioSnapshotRequest request = activePortfolioRequest;
+        if (request == null) {
+            return;
+        }
+        if (!request.matchesAccount(accountName)) {
+            return;
+        }
+        request.recordAccountName(accountName);
+        double parsed;
+        try {
+            parsed = Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return;
+        }
+        String cur = normalizeCurrency(currency);
+        if ("AVAILABLEFUNDS".equalsIgnoreCase(key)) {
+            request.putAvailableFunds(cur, parsed);
+        } else if ("TOTALCASHVALUE".equalsIgnoreCase(key)) {
+            request.putCashBalance(cur, parsed);
+        } else if ("NETLIQUIDATION".equalsIgnoreCase(key)) {
+            request.putNetLiquidation(cur, parsed);
+        }
+    }
+
+    @Override
+    public void updatePortfolio(Contract contract, Decimal position, double marketPrice, double marketValue,
+                                double averageCost, double unrealizedPNL, double realizedPNL, String accountName) {
+        PortfolioSnapshotRequest request = activePortfolioRequest;
+        if (request == null) {
+            return;
+        }
+        if (!request.matchesAccount(accountName)) {
+            return;
+        }
+        request.recordAccountName(accountName);
+        double qty = position != null ? position.doubleValue() : 0d;
+        String key = portfolioKey(contract);
+        request.positions.compute(key, (k, existing) -> {
+            PositionData data = existing;
+            if (data == null) {
+                data = new PositionData(accountName, contract);
+            } else if (accountName != null && !accountName.isBlank()) {
+                data.account = accountName;
+            }
+            data.position = qty;
+            data.marketPrice = marketPrice;
+            data.marketValue = marketValue;
+            return data;
+        });
+    }
+
+    @Override
+    public void accountDownloadEnd(String accountName) {
+        PortfolioSnapshotRequest request = activePortfolioRequest;
+        if (request == null) {
+            return;
+        }
+        if (!request.matchesAccount(accountName)) {
+            return;
+        }
+        request.recordAccountName(accountName);
+        completePortfolioSnapshot(request);
+    }
 
     @Override
     public void tickPrice(int tickerId, int field, double price, TickAttrib attribs) {
@@ -404,250 +711,6 @@ public class IbkrFxService extends IbkrWrapperAdapter {
             // Tri chrono si nécessaire (IB envoie souvent déjà trié)
             buf.sort(Comparator.comparingLong(HistBar::tsMillis));
             fut.complete(buf);
-        }
-    }
-
-    /** ----------- ACCOUNT / PORTFOLIO ----------- */
-
-    public PortfolioSnapshot fetchPortfolioSnapshot(String account) {
-        return fetchPortfolioSnapshot(account, 5000);
-    }
-
-    public PortfolioSnapshot fetchPortfolioSnapshot(String account, long timeoutMs) {
-        if (!client.isConnected()) {
-            throw new IllegalStateException("Not connected to TWS/IB Gateway");
-        }
-        long effectiveTimeout = timeoutMs <= 0 ? 5000 : timeoutMs;
-        PortfolioRequest request = new PortfolioRequest(account);
-        synchronized (portfolioLock) {
-            if (currentPortfolioRequest != null) {
-                throw new IllegalStateException("Another portfolio request is already in progress");
-            }
-            currentPortfolioRequest = request;
-        }
-
-        try {
-            client.reqAccountUpdates(true, request.requestedAccount());
-            return request.future().get(effectiveTimeout, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            request.markCompleted();
-            request.future().completeExceptionally(e);
-            throw new RuntimeException("Interrupted while waiting for IBKR portfolio", e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            request.markCompleted();
-            throw new RuntimeException("Failed to fetch IBKR portfolio: " + cause.getMessage(), cause);
-        } catch (TimeoutException e) {
-            request.markCompleted();
-            request.future().completeExceptionally(e);
-            throw new RuntimeException("Timed out waiting for IBKR portfolio", e);
-        } finally {
-            try {
-                client.reqAccountUpdates(false, request.requestedAccount());
-            } catch (Exception ignored) {
-            }
-            synchronized (portfolioLock) {
-                currentPortfolioRequest = null;
-            }
-        }
-    }
-
-    @Override
-    public void updateAccountValue(String key, String value, String currency, String accountName) {
-        PortfolioRequest request = currentPortfolioRequest;
-        if (request == null || !request.matchesAccount(accountName)) return;
-        if (value == null || value.isBlank()) return;
-        try {
-            double numericValue = Double.parseDouble(value);
-            request.setCurrencyIfAbsent(currency);
-            switch (key) {
-                case "AvailableFunds" -> request.setAvailableFunds(numericValue);
-                case "NetLiquidation" -> request.setNetLiquidation(numericValue);
-                case "GrossPositionValue" -> request.setGrossPositionValue(numericValue);
-                default -> {
-                }
-            }
-        } catch (NumberFormatException ignored) {
-        }
-    }
-
-    @Override
-    public void updatePortfolio(Contract contract, double position, double marketPrice, double marketValue,
-                                double averageCost, double unrealizedPNL, double realizedPNL, String accountName) {
-        PortfolioRequest request = currentPortfolioRequest;
-        if (request == null || !request.matchesAccount(accountName)) return;
-        String key = positionKey(contract);
-        PortfolioPositionAccumulator accumulator = request.positions().computeIfAbsent(key, k -> new PortfolioPositionAccumulator(contract));
-        accumulator.position = position;
-        accumulator.marketPrice = marketPrice;
-        accumulator.marketValue = marketValue;
-        accumulator.averageCost = averageCost;
-        accumulator.unrealizedPnl = unrealizedPNL;
-        accumulator.realizedPnl = realizedPNL;
-    }
-
-    @Override
-    public void accountDownloadEnd(String accountName) {
-        PortfolioRequest request = currentPortfolioRequest;
-        if (request == null || !request.matchesAccount(accountName) || request.future().isDone()) return;
-
-        double totalPositionsValue = request.positions().values().stream()
-                .mapToDouble(p -> Math.abs(p.marketValue))
-                .sum();
-
-        List<PositionBreakdown> positions = request.positions().values().stream()
-                .sorted(Comparator.comparingDouble((PortfolioPositionAccumulator p) -> Math.abs(p.marketValue)).reversed())
-                .map(acc -> toPositionBreakdown(acc, totalPositionsValue))
-                .toList();
-
-        double grossPositionValue = Double.isNaN(request.grossPositionValue()) ? totalPositionsValue : request.grossPositionValue();
-
-        PortfolioSnapshot snapshot = new PortfolioSnapshot(
-                request.effectiveAccount(),
-                request.currency(),
-                sanitizeDouble(request.availableFunds()),
-                sanitizeDouble(request.netLiquidation()),
-                sanitizeDouble(grossPositionValue),
-                totalPositionsValue,
-                positions
-        );
-
-        request.markCompleted();
-        request.future().complete(snapshot);
-    }
-
-    private double sanitizeDouble(double value) {
-        return Double.isFinite(value) ? value : 0.0;
-    }
-
-    private PositionBreakdown toPositionBreakdown(PortfolioPositionAccumulator acc, double totalPositionsValue) {
-        Contract contract = acc.contract;
-        double allocation = totalPositionsValue == 0.0 ? 0.0 : Math.abs(acc.marketValue) / totalPositionsValue;
-        return new PositionBreakdown(
-                contract != null ? contract.conid() : 0,
-                contract != null ? nullToEmpty(contract.symbol()) : "",
-                contract != null ? nullToEmpty(contract.localSymbol()) : "",
-                contract != null ? nullToEmpty(contract.secType()) : "",
-                contract != null ? nullToEmpty(contract.currency()) : "",
-                acc.position,
-                acc.marketPrice,
-                acc.marketValue,
-                allocation
-        );
-    }
-
-    private String nullToEmpty(String value) {
-        return value == null ? "" : value;
-    }
-
-    private String positionKey(Contract contract) {
-        if (contract == null) return "UNKNOWN";
-        int conid = contract.conid();
-        if (conid != 0) {
-            return "CONID:" + conid;
-        }
-        return (nullToEmpty(contract.symbol()) + ':' + nullToEmpty(contract.secType()) + ':' + nullToEmpty(contract.currency()) + ':' + nullToEmpty(contract.exchange())).toUpperCase(Locale.ROOT);
-    }
-
-    private static class PortfolioRequest {
-        private final String requestedAccount;
-        private final CompletableFuture<PortfolioSnapshot> future = new CompletableFuture<>();
-        private final Map<String, PortfolioPositionAccumulator> positions = new LinkedHashMap<>();
-        private volatile double availableFunds = Double.NaN;
-        private volatile double netLiquidation = Double.NaN;
-        private volatile double grossPositionValue = Double.NaN;
-        private volatile String currency;
-        private volatile String effectiveAccount;
-        private volatile boolean completed;
-
-        PortfolioRequest(String requestedAccount) {
-            this.requestedAccount = requestedAccount == null ? "" : requestedAccount.trim();
-        }
-
-        String requestedAccount() {
-            return requestedAccount;
-        }
-
-        CompletableFuture<PortfolioSnapshot> future() {
-            return future;
-        }
-
-        Map<String, PortfolioPositionAccumulator> positions() {
-            return positions;
-        }
-
-        double availableFunds() {
-            return availableFunds;
-        }
-
-        double netLiquidation() {
-            return netLiquidation;
-        }
-
-        double grossPositionValue() {
-            return grossPositionValue;
-        }
-
-        String currency() {
-            return currency;
-        }
-
-        String effectiveAccount() {
-            return effectiveAccount == null ? requestedAccount : effectiveAccount;
-        }
-
-        boolean matchesAccount(String accountName) {
-            if (completed) return false;
-            if (accountName == null || accountName.isBlank()) {
-                return requestedAccount.isBlank() || Objects.equals(effectiveAccount, accountName);
-            }
-            if (!requestedAccount.isBlank() && !requestedAccount.equals(accountName)) {
-                return false;
-            }
-            if (effectiveAccount != null && !effectiveAccount.equals(accountName)) {
-                return false;
-            }
-            if (effectiveAccount == null) {
-                effectiveAccount = accountName;
-            }
-            return true;
-        }
-
-        void setCurrencyIfAbsent(String newCurrency) {
-            if (this.currency == null && newCurrency != null && !newCurrency.isBlank()) {
-                this.currency = newCurrency;
-            }
-        }
-
-        void setAvailableFunds(double value) {
-            this.availableFunds = value;
-        }
-
-        void setNetLiquidation(double value) {
-            this.netLiquidation = value;
-        }
-
-        void setGrossPositionValue(double value) {
-            this.grossPositionValue = value;
-        }
-
-        void markCompleted() {
-            this.completed = true;
-        }
-    }
-
-    private static class PortfolioPositionAccumulator {
-        final Contract contract;
-        double position;
-        double marketPrice;
-        double marketValue;
-        double averageCost;
-        double unrealizedPnl;
-        double realizedPnl;
-
-        PortfolioPositionAccumulator(Contract contract) {
-            this.contract = contract;
         }
     }
 


### PR DESCRIPTION
## Summary
- extend the IBKR FX service with portfolio snapshot collection, exposing liquidity, net liquidation and position allocations
- add a new `/ibkr/portfolio` endpoint that allows choosing the broker, optional account code and timeout

## Testing
- `mvn -q -DskipTests compile` *(fails: missing com.ib:tws-api dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_690551e5b358832398952a469e8268e0