### PR TITLE
Add IBKR portfolio snapshot endpoint

### DIFF
--- a/src/main/java/finance/project/api/controllers/PortfolioController.java
+++ b/src/main/java/finance/project/api/controllers/PortfolioController.java
@@ -1,0 +1,37 @@
+package finance.project.api.controllers;
+
+import finance.project.api.model.PortfolioSnapshotDTO;
+import finance.project.api.services.BrokerTradeService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/portfolio")
+public class PortfolioController {
+
+    private final Map<String, BrokerTradeService> servicesById;
+
+    public PortfolioController(List<BrokerTradeService> services) {
+        Map<String, BrokerTradeService> map = new HashMap<>();
+        for (var s : services) {
+            map.put(s.brokerId().toUpperCase(Locale.ROOT), s);
+        }
+        this.servicesById = Map.copyOf(map);
+    }
+
+    @GetMapping
+    public PortfolioSnapshotDTO fetchPortfolio(@RequestParam(defaultValue = "IBKR") String broker) throws Exception {
+        BrokerTradeService svc = servicesById.get(broker.toUpperCase(Locale.ROOT));
+        if (svc == null) {
+            throw new IllegalArgumentException("Unknown broker: " + broker + " (available: " + servicesById.keySet() + ")");
+        }
+        return svc.fetchPortfolioSnapshot();
+    }
+}

--- a/src/main/java/finance/project/api/model/PortfolioPositionDTO.java
+++ b/src/main/java/finance/project/api/model/PortfolioPositionDTO.java
@@ -1,0 +1,22 @@
+package finance.project.api.model;
+
+/**
+ * Détail d'une position de portefeuille renvoyée par un broker.
+ */
+public record PortfolioPositionDTO(
+        String broker,
+        String account,
+        String symbol,
+        String description,
+        String securityType,
+        String currency,
+        String exchange,
+        Integer contractId,
+        double position,
+        double marketPrice,
+        double marketValue,
+        double averageCost,
+        double unrealizedPnL,
+        double realizedPnL,
+        double relativeValue
+) {}

--- a/src/main/java/finance/project/api/model/PortfolioSnapshotDTO.java
+++ b/src/main/java/finance/project/api/model/PortfolioSnapshotDTO.java
@@ -1,0 +1,14 @@
+package finance.project.api.model;
+
+import java.util.List;
+
+/**
+ * Vue agrégée d'un portefeuille renvoyée par un broker.
+ */
+public record PortfolioSnapshotDTO(
+        String broker,
+        double totalMarketValue,
+        double availableLiquidity,
+        List<PortfolioPositionDTO> positions,
+        long asOf
+) {}

--- a/src/main/java/finance/project/api/services/BrokerTradeService.java
+++ b/src/main/java/finance/project/api/services/BrokerTradeService.java
@@ -1,5 +1,6 @@
 package finance.project.api.services;
 
+import finance.project.api.model.PortfolioSnapshotDTO;
 import finance.project.api.model.TradeViewDTO;
 
 import java.util.List;
@@ -10,4 +11,7 @@ public interface BrokerTradeService {
 
     /** Liste des positions/trades en cours (timeout interne raisonnable) */
     List<TradeViewDTO> listOpenTrades() throws Exception;
+
+    /** Récupère un snapshot agrégé du portefeuille du broker. */
+    PortfolioSnapshotDTO fetchPortfolioSnapshot() throws Exception;
 }

--- a/src/main/java/finance/project/api/services/IbkrTradeService.java
+++ b/src/main/java/finance/project/api/services/IbkrTradeService.java
@@ -1,6 +1,8 @@
 package finance.project.api.services;
 
 import com.ib.client.Decimal;
+import finance.project.api.model.PortfolioPositionDTO;
+import finance.project.api.model.PortfolioSnapshotDTO;
 import finance.project.api.model.TradeViewDTO;
 import org.springframework.stereotype.Service;
 
@@ -36,7 +38,7 @@ public class IbkrTradeService implements BrokerTradeService {
         if (!ib.isConnected()) {
             throw new IllegalStateException("IBKR non connecté. Appelle d’abord /ibkr/connect/wait.");
         }
-        long now = java.time.Instant.now().toEpochMilli();
+        long now = Instant.now().toEpochMilli();
 
         // 1) tentative reqPositions()
         var pos = ib.fetchOpenPositions(4000L);
@@ -90,6 +92,62 @@ public class IbkrTradeService implements BrokerTradeService {
                 .toList();
     }
 
+    @Override
+    public PortfolioSnapshotDTO fetchPortfolioSnapshot() throws Exception {
+        if (!ib.isConnected()) {
+            throw new IllegalStateException("IBKR non connecté. Appelle d’abord /ibkr/connect/wait.");
+        }
+        long now = Instant.now().toEpochMilli();
+
+        var snapshot = ib.fetchPortfolioSnapshot(5000L);
+        double totalMarketValue = snapshot.stream()
+                .mapToDouble(IbkrFxService.IbPortfolioLine::marketValue)
+                .sum();
+        double availableLiquidity = snapshot.stream()
+                .filter(IbkrTradeService::isCashLine)
+                .mapToDouble(IbkrFxService.IbPortfolioLine::marketValue)
+                .sum();
+        double investedMarketValue = snapshot.stream()
+                .filter(line -> !isCashLine(line))
+                .mapToDouble(IbkrFxService.IbPortfolioLine::marketValue)
+                .sum();
+
+        List<PortfolioPositionDTO> positions = snapshot.stream()
+                .map(line -> {
+                    var contract = line.contract();
+                    double marketValue = line.marketValue();
+                    double relative = (!isCashLine(line) && Math.abs(investedMarketValue) > 1e-9)
+                            ? marketValue / investedMarketValue
+                            : 0d;
+                    return new PortfolioPositionDTO(
+                            "IBKR",
+                            line.account(),
+                            buildSymbol(contract),
+                            buildDescription(contract),
+                            safe(contract.secType().getApiString()),
+                            safe(contract.currency()),
+                            safe(contract.exchange()),
+                            contract.conid() > 0 ? contract.conid() : null,
+                            toDouble(line.position()),
+                            line.marketPrice(),
+                            marketValue,
+                            line.averageCost(),
+                            line.unrealizedPNL(),
+                            line.realizedPNL(),
+                            relative
+                    );
+                })
+                .toList();
+
+        return new PortfolioSnapshotDTO(
+                "IBKR",
+                totalMarketValue,
+                availableLiquidity,
+                positions,
+                now
+        );
+    }
+
 
     private static String safe(String s) { return (s == null || s.isBlank()) ? null : s; }
 
@@ -111,5 +169,11 @@ public class IbkrTradeService implements BrokerTradeService {
         String base = (safe(c.symbol()) + "." + safe(c.currency()) + " " + safe(c.exchange())
                 + " (" + safe(c.secType().getApiString()) + ")").replace("null", "");
         return base.trim();
+    }
+
+    private static boolean isCashLine(IbkrFxService.IbPortfolioLine line) {
+        var secType = line.contract().secType();
+        String type = secType != null ? secType.getApiString() : null;
+        return type != null && type.equalsIgnoreCase("CASH");
     }
 }


### PR DESCRIPTION
## Summary
- add DTOs to expose portfolio positions and aggregated snapshots
- extend the IBKR trade service to compute liquidity, total value, and relative weights
- provide a /portfolio endpoint to query the snapshot for a chosen broker

## Testing
- ./mvnw -q -DskipTests compile *(fails: missing com.ib:tws-api dependencies in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_6906609bd20083239edbb10051c6f943