### PR TITLE
Add live signal ingestion endpoint with SSE broadcasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ mvn install:install-file -Dfile=jar\protobuf-java-4.29.3.jar -DgroupId=com.ib -D
    mvn clean install
    mvn spring-boot:run
    ```
+
+## Live ingest + SSE
+
+- **Variables d'environnement** : `LIVE_HMAC_SECRET` (obligatoire uniquement lorsque `app.live.ingest.hmacEnabled=true`).
+- **Endpoints** :
+  - `POST /live/signal` — ingestion d'un signal live avec idempotence basée sur `uniqHash`.
+  - `GET /live/stream` — flux SSE temps réel des signaux acceptés.
+  - `GET /live/recent` — liste des signaux enregistrés sur la période demandée (`lookback`, par défaut `PT6H`).
+- **Idempotence** : les signaux sont identifiés par la valeur SHA-256 `uniqHash` (`strategyId|symbol|timeframe|tsOpenUtc|side|entryPrice|sl|tp`). Un doublon est reconnu et ignoré côté base, mais rediffusé via SSE.
+- **Sécurité** : option HMAC via l'entête configuré (`app.live.ingest.hmacHeader`), calculé sur le JSON canonique du signal.
+- **Documentation** : l'interface OpenAPI/Swagger est disponible sur `/swagger-ui`.
+
 ## Contribution
 
 Les contributions sont les bienvenues ! Si vous souhaitez proposer des améliorations ou corriger des bugs, veuillez ouvrir une issue ou soumettre une pull request.

--- a/pom.xml
+++ b/pom.xml
@@ -95,15 +95,20 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.6.0</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <optional>true</optional>
+                </dependency>
 		<!--
 		<dependency>
 			<groupId>com.h2database</groupId>
@@ -150,11 +155,16 @@
 		</dependency>
 
 		<!-- JSON Parsing -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/yourapp/live/LiveAckResponse.java
+++ b/src/main/java/com/yourapp/live/LiveAckResponse.java
@@ -1,0 +1,3 @@
+package com.yourapp.live;
+
+public record LiveAckResponse(boolean ok, String message) {}

--- a/src/main/java/com/yourapp/live/LiveController.java
+++ b/src/main/java/com/yourapp/live/LiveController.java
@@ -1,0 +1,56 @@
+package com.yourapp.live;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/live")
+public class LiveController {
+
+  private final LiveSignalService service;
+  private final LiveSseHub hub;
+
+  public LiveController(LiveSignalService service, LiveSseHub hub) {
+    this.service = service;
+    this.hub = hub;
+  }
+
+  @Operation(summary = "Ingest live trade signal")
+  @PostMapping("/signal")
+  public ResponseEntity<LiveAckResponse> signal(
+      @RequestBody @Valid LiveSignalDTO dto,
+      @RequestHeader(name = "#{@liveProps.ingest().hmacHeader}", required = false) String hmac) {
+    LiveAckResponse response = service.ingest(dto, hmac);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "SSE stream of live trades")
+  @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter stream() {
+    return hub.subscribe();
+  }
+
+  @GetMapping("/recent")
+  public List<LiveTradeAck> recent(@RequestParam(defaultValue = "PT6H") String lookback) {
+    try {
+      return service.recent(Duration.parse(lookback));
+    } catch (DateTimeParseException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid_lookback", ex);
+    }
+  }
+}

--- a/src/main/java/com/yourapp/live/LiveProps.java
+++ b/src/main/java/com/yourapp/live/LiveProps.java
@@ -1,0 +1,11 @@
+package com.yourapp.live;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.live")
+public record LiveProps(Ingest ingest, Sse sse) {
+
+  public record Ingest(boolean hmacEnabled, String hmacHeader, String hmacSecretEnv) {}
+
+  public record Sse(long heartbeatMillis) {}
+}

--- a/src/main/java/com/yourapp/live/LiveSignalDTO.java
+++ b/src/main/java/com/yourapp/live/LiveSignalDTO.java
@@ -1,0 +1,18 @@
+package com.yourapp.live;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.Map;
+
+public record LiveSignalDTO(
+    @NotBlank String strategyId,
+    @NotBlank String symbol,
+    @NotBlank String timeframe,
+    @NotNull Instant tsOpenUtc,
+    @NotBlank String side,
+    @NotNull Double entryPrice,
+    Double sl,
+    Double tp,
+    Double expectedRr,
+    Map<String, Object> payload) {}

--- a/src/main/java/com/yourapp/live/LiveSignalService.java
+++ b/src/main/java/com/yourapp/live/LiveSignalService.java
@@ -1,0 +1,216 @@
+package com.yourapp.live;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.lang.Nullable;
+
+@Service
+public class LiveSignalService {
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+  private final LiveTradeAckRepository repo;
+  private final LiveSseHub sseHub;
+  private final LiveProps props;
+  private final ObjectMapper objectMapper;
+
+  public LiveSignalService(
+      LiveTradeAckRepository repo, LiveSseHub sseHub, LiveProps props, ObjectMapper objectMapper) {
+    this.repo = repo;
+    this.sseHub = sseHub;
+    this.props = props;
+    this.objectMapper = objectMapper;
+  }
+
+  @Transactional
+  public LiveAckResponse ingest(LiveSignalDTO dto, @Nullable String hmacHeader) {
+    if (props.ingest() != null && props.ingest().hmacEnabled()) {
+      verifyHmac(dto, hmacHeader);
+    }
+
+    String uniq = computeUniqHash(dto);
+    return repo
+        .findByUniqHash(uniq)
+        .map(
+            existing -> {
+              sseHub.broadcast(existing);
+              return new LiveAckResponse(true, "duplicate_ignored");
+            })
+        .orElseGet(
+            () -> {
+              LiveTradeAck entity = map(dto, uniq);
+              repo.save(entity);
+              sseHub.broadcast(entity);
+              return new LiveAckResponse(true, "accepted");
+            });
+  }
+
+  public List<LiveTradeAck> recent(Duration lookback) {
+    if (lookback.isNegative()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "lookback_negative");
+    }
+    Instant since = Instant.now().minus(lookback);
+    return repo.findRecent(since);
+  }
+
+  private void verifyHmac(LiveSignalDTO dto, @Nullable String header) {
+    if (!StringUtils.hasText(header)) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "missing_hmac_header");
+    }
+    String secretEnv = props.ingest().hmacSecretEnv();
+    if (!StringUtils.hasText(secretEnv)) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "missing_hmac_secret_env");
+    }
+    String secret = System.getenv(secretEnv);
+    if (!StringUtils.hasText(secret)) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "hmac_secret_not_available");
+    }
+
+    String canonicalJson = canonicalJson(dto);
+    String expected;
+    try {
+      Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+      mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+      byte[] digest = mac.doFinal(canonicalJson.getBytes(StandardCharsets.UTF_8));
+      expected = toHex(digest);
+    } catch (GeneralSecurityException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "hmac_failure", e);
+    }
+
+    String provided = header.trim().toLowerCase();
+    if (!MessageDigest.isEqual(
+        expected.getBytes(StandardCharsets.UTF_8), provided.getBytes(StandardCharsets.UTF_8))) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid_hmac");
+    }
+  }
+
+  private LiveTradeAck map(LiveSignalDTO dto, String uniq) {
+    LiveTradeAck entity = new LiveTradeAck();
+    entity.setStrategyId(dto.strategyId());
+    entity.setSymbol(dto.symbol());
+    entity.setTimeframe(dto.timeframe());
+    entity.setTsOpenUtc(dto.tsOpenUtc());
+    entity.setSide(parseSide(dto.side()));
+    entity.setEntryPrice(dto.entryPrice());
+    entity.setSl(dto.sl());
+    entity.setTp(dto.tp());
+    entity.setExpectedRr(dto.expectedRr());
+    entity.setUniqHash(uniq);
+    entity.setSignalPayloadJson(serializePayload(dto.payload()));
+    entity.setCreatedAt(Instant.now());
+    return entity;
+  }
+
+  private LiveTradeAck.Side parseSide(String side) {
+    try {
+      return LiveTradeAck.Side.valueOf(side.toUpperCase());
+    } catch (IllegalArgumentException ex) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid_side");
+    }
+  }
+
+  private String serializePayload(Map<String, Object> payload) {
+    if (payload == null || payload.isEmpty()) {
+      return null;
+    }
+    try {
+      return objectMapper.writeValueAsString(payload);
+    } catch (JsonProcessingException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "payload_serialization_error", e);
+    }
+  }
+
+  private String computeUniqHash(LiveSignalDTO dto) {
+    String raw = String.join(
+        "|",
+        dto.strategyId(),
+        dto.symbol(),
+        dto.timeframe(),
+        dto.tsOpenUtc().toString(),
+        dto.side().toUpperCase(),
+        String.valueOf(dto.entryPrice()),
+        dto.sl() != null ? dto.sl().toString() : "null",
+        dto.tp() != null ? dto.tp().toString() : "null");
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hash = digest.digest(raw.getBytes(StandardCharsets.UTF_8));
+      return toHex(hash);
+    } catch (GeneralSecurityException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "hash_failure", e);
+    }
+  }
+
+  private String canonicalJson(LiveSignalDTO dto) {
+    Map<String, Object> root = new LinkedHashMap<>();
+    root.put("strategyId", dto.strategyId());
+    root.put("symbol", dto.symbol());
+    root.put("timeframe", dto.timeframe());
+    root.put("tsOpenUtc", dto.tsOpenUtc().toString());
+    root.put("side", dto.side().toUpperCase());
+    root.put("entryPrice", dto.entryPrice());
+    root.put("sl", dto.sl());
+    root.put("tp", dto.tp());
+    root.put("expectedRr", dto.expectedRr());
+    root.put("payload", dto.payload() == null ? null : normalizeValue(dto.payload()));
+
+    ObjectMapper canonicalMapper = objectMapper.copy();
+    canonicalMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    try {
+      return canonicalMapper.writeValueAsString(root);
+    } catch (JsonProcessingException e) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "canonical_json_error", e);
+    }
+  }
+
+  private Object normalizeValue(Object value) {
+    if (value instanceof Map<?, ?> map) {
+      Map<String, Object> sorted = new TreeMap<>();
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+        sorted.put(String.valueOf(entry.getKey()), normalizeValue(entry.getValue()));
+      }
+      return sorted;
+    }
+    if (value instanceof Iterable<?> iterable) {
+      List<Object> normalized = new ArrayList<>();
+      for (Object element : iterable) {
+        normalized.add(normalizeValue(element));
+      }
+      return normalized;
+    }
+    if (value != null && value.getClass().isArray()) {
+      int length = java.lang.reflect.Array.getLength(value);
+      List<Object> normalized = new ArrayList<>(length);
+      for (int i = 0; i < length; i++) {
+        normalized.add(normalizeValue(java.lang.reflect.Array.get(value, i)));
+      }
+      return normalized;
+    }
+    return value;
+  }
+
+  private String toHex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/yourapp/live/LiveSseHub.java
+++ b/src/main/java/com/yourapp/live/LiveSseHub.java
@@ -1,0 +1,109 @@
+package com.yourapp.live;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+public class LiveSseHub {
+
+  private static final TypeReference<Map<String, Object>> MAP_TYPE =
+      new TypeReference<>() {};
+
+  private final Set<SseEmitter> clients = ConcurrentHashMap.newKeySet();
+  private final LiveProps props;
+  private final ObjectMapper objectMapper;
+  private final Supplier<SseEmitter> emitterSupplier;
+  private final ScheduledExecutorService scheduler;
+
+  public LiveSseHub(LiveProps props, ObjectMapper objectMapper) {
+    this(props, objectMapper, () -> new SseEmitter(0L));
+  }
+
+  LiveSseHub(
+      LiveProps props, ObjectMapper objectMapper, Supplier<SseEmitter> emitterSupplier) {
+    this.props = props;
+    this.objectMapper = objectMapper;
+    this.emitterSupplier = emitterSupplier;
+    this.scheduler = Executors.newSingleThreadScheduledExecutor();
+    long heartbeat = props.sse() != null ? props.sse().heartbeatMillis() : 15000L;
+    if (heartbeat > 0) {
+      scheduler.scheduleAtFixedRate(
+          this::heartbeat, heartbeat, heartbeat, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public SseEmitter subscribe() {
+    SseEmitter emitter = emitterSupplier.get();
+    clients.add(emitter);
+    emitter.onCompletion(() -> clients.remove(emitter));
+    emitter.onTimeout(() -> clients.remove(emitter));
+    send(emitter, "hello", Map.of("ts", Instant.now().toString()));
+    return emitter;
+  }
+
+  public void broadcast(LiveTradeAck ack) {
+    clients.forEach(em -> send(em, "trade", ackToMap(ack)));
+  }
+
+  private void heartbeat() {
+    clients.forEach(em -> send(em, "heartbeat", Map.of("ts", Instant.now().toString())));
+  }
+
+  private void send(SseEmitter emitter, String event, Object data) {
+    try {
+      emitter.send(SseEmitter.event().name(event).data(data));
+    } catch (IOException ex) {
+      clients.remove(emitter);
+    }
+  }
+
+  private Map<String, Object> ackToMap(LiveTradeAck ack) {
+    Map<String, Object> payload = parsePayload(ack.getSignalPayloadJson());
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("id", ack.getId());
+    map.put("strategyId", ack.getStrategyId());
+    map.put("symbol", ack.getSymbol());
+    map.put("timeframe", ack.getTimeframe());
+    map.put("tsOpenUtc", ack.getTsOpenUtc());
+    map.put("side", ack.getSide() != null ? ack.getSide().name() : null);
+    map.put("entryPrice", ack.getEntryPrice());
+    map.put("sl", ack.getSl());
+    map.put("tp", ack.getTp());
+    map.put("expectedRr", ack.getExpectedRr());
+    map.put("payload", payload);
+    map.put("uniqHash", ack.getUniqHash());
+    map.put("createdAt", ack.getCreatedAt());
+    return map;
+  }
+
+  private Map<String, Object> parsePayload(String json) {
+    if (json == null || json.isBlank()) {
+      return null;
+    }
+    try {
+      return objectMapper.readValue(json, MAP_TYPE);
+    } catch (IOException e) {
+      return Map.of("raw", json);
+    }
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    scheduler.shutdownNow();
+    clients.forEach(SseEmitter::complete);
+    clients.clear();
+  }
+}

--- a/src/main/java/com/yourapp/live/LiveTradeAck.java
+++ b/src/main/java/com/yourapp/live/LiveTradeAck.java
@@ -1,0 +1,168 @@
+package com.yourapp.live;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "trades_live_ack",
+    uniqueConstraints = @UniqueConstraint(name = "ux_uniq_hash", columnNames = "uniqHash"))
+public class LiveTradeAck {
+
+  public enum Side {
+    LONG,
+    SHORT
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String strategyId;
+
+  @Column(nullable = false)
+  private String symbol;
+
+  @Column(nullable = false)
+  private String timeframe;
+
+  @Column(nullable = false)
+  private Instant tsOpenUtc;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Side side;
+
+  @Column(nullable = false)
+  private double entryPrice;
+
+  private Double sl;
+
+  private Double tp;
+
+  private Double expectedRr;
+
+  @Column(nullable = false, length = 64)
+  private String uniqHash;
+
+  @Column(columnDefinition = "text")
+  private String signalPayloadJson;
+
+  @Column(nullable = false)
+  private Instant createdAt = Instant.now();
+
+  public LiveTradeAck() {}
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getStrategyId() {
+    return strategyId;
+  }
+
+  public void setStrategyId(String strategyId) {
+    this.strategyId = strategyId;
+  }
+
+  public String getSymbol() {
+    return symbol;
+  }
+
+  public void setSymbol(String symbol) {
+    this.symbol = symbol;
+  }
+
+  public String getTimeframe() {
+    return timeframe;
+  }
+
+  public void setTimeframe(String timeframe) {
+    this.timeframe = timeframe;
+  }
+
+  public Instant getTsOpenUtc() {
+    return tsOpenUtc;
+  }
+
+  public void setTsOpenUtc(Instant tsOpenUtc) {
+    this.tsOpenUtc = tsOpenUtc;
+  }
+
+  public Side getSide() {
+    return side;
+  }
+
+  public void setSide(Side side) {
+    this.side = side;
+  }
+
+  public double getEntryPrice() {
+    return entryPrice;
+  }
+
+  public void setEntryPrice(double entryPrice) {
+    this.entryPrice = entryPrice;
+  }
+
+  public Double getSl() {
+    return sl;
+  }
+
+  public void setSl(Double sl) {
+    this.sl = sl;
+  }
+
+  public Double getTp() {
+    return tp;
+  }
+
+  public void setTp(Double tp) {
+    this.tp = tp;
+  }
+
+  public Double getExpectedRr() {
+    return expectedRr;
+  }
+
+  public void setExpectedRr(Double expectedRr) {
+    this.expectedRr = expectedRr;
+  }
+
+  public String getUniqHash() {
+    return uniqHash;
+  }
+
+  public void setUniqHash(String uniqHash) {
+    this.uniqHash = uniqHash;
+  }
+
+  public String getSignalPayloadJson() {
+    return signalPayloadJson;
+  }
+
+  public void setSignalPayloadJson(String signalPayloadJson) {
+    this.signalPayloadJson = signalPayloadJson;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Instant createdAt) {
+    this.createdAt = createdAt;
+  }
+}

--- a/src/main/java/com/yourapp/live/LiveTradeAckRepository.java
+++ b/src/main/java/com/yourapp/live/LiveTradeAckRepository.java
@@ -1,0 +1,15 @@
+package com.yourapp.live;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LiveTradeAckRepository extends JpaRepository<LiveTradeAck, Long> {
+  Optional<LiveTradeAck> findByUniqHash(String uniqHash);
+
+  @Query("select a from LiveTradeAck a where a.tsOpenUtc >= :since order by a.tsOpenUtc desc")
+  List<LiveTradeAck> findRecent(@Param("since") Instant since);
+}

--- a/src/main/java/finance/project/api/Application.java
+++ b/src/main/java/finance/project/api/Application.java
@@ -2,8 +2,10 @@ package finance.project.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"finance.project.api", "com.yourapp.live"})
+@ConfigurationPropertiesScan("com.yourapp.live")
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+app:
+  live:
+    ingest:
+      hmacEnabled: false
+      hmacHeader: X-Live-Hmac
+      hmacSecretEnv: LIVE_HMAC_SECRET
+    sse:
+      heartbeatMillis: 15000

--- a/src/test/java/com/yourapp/live/LiveControllerTest.java
+++ b/src/test/java/com/yourapp/live/LiveControllerTest.java
@@ -1,0 +1,94 @@
+package com.yourapp.live;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LiveControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private LiveTradeAckRepository repository;
+
+  @MockBean private LiveSseHub liveSseHub;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+    reset(liveSseHub);
+  }
+
+  @Test
+  void shouldAcceptSignalAndIgnoreDuplicate() throws Exception {
+    LiveSignalDTO dto = baseDto();
+
+    mockMvc
+        .perform(
+            post("/live/signal")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(dto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("accepted"));
+
+    mockMvc
+        .perform(
+            post("/live/signal")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(dto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.message").value("duplicate_ignored"));
+
+    verify(liveSseHub, times(2)).broadcast(any(LiveTradeAck.class));
+  }
+
+  @Test
+  void shouldReturnRecentSignals() throws Exception {
+    LiveSignalDTO dto = baseDto();
+    mockMvc
+        .perform(
+            post("/live/signal")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(dto)))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(get("/live/recent").param("lookback", "PT24H"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].strategyId").value(dto.strategyId()));
+  }
+
+  private LiveSignalDTO baseDto() {
+    return new LiveSignalDTO(
+        "strat-1",
+        "EURUSD",
+        "M15",
+        Instant.now(),
+        "LONG",
+        1.2345,
+        1.2000,
+        1.3000,
+        2.5,
+        Map.of("note", "test"));
+  }
+}

--- a/src/test/java/com/yourapp/live/LiveSseHubTest.java
+++ b/src/test/java/com/yourapp/live/LiveSseHubTest.java
@@ -1,0 +1,111 @@
+package com.yourapp.live;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class LiveSseHubTest {
+
+  @Test
+  void shouldSendHandshakeAndTradeEvent() throws Exception {
+    LiveProps props =
+        new LiveProps(
+            new LiveProps.Ingest(false, "X-Live-Hmac", "LIVE_HMAC_SECRET"),
+            new LiveProps.Sse(0L));
+    ObjectMapper mapper = new ObjectMapper();
+    AtomicReference<TestEmitter> ref = new AtomicReference<>();
+    LiveSseHub hub = new LiveSseHub(props, mapper, () -> {
+      TestEmitter emitter = new TestEmitter();
+      ref.set(emitter);
+      return emitter;
+    });
+
+    try {
+      SseEmitter emitter = hub.subscribe();
+      assertThat(emitter).isInstanceOf(TestEmitter.class);
+
+      LiveTradeAck ack = new LiveTradeAck();
+      ack.setId(1L);
+      ack.setStrategyId("strategy-x");
+      ack.setSymbol("EURUSD");
+      ack.setTimeframe("M5");
+      ack.setTsOpenUtc(Instant.parse("2024-01-01T00:00:00Z"));
+      ack.setSide(LiveTradeAck.Side.LONG);
+      ack.setEntryPrice(1.234);
+      ack.setSl(1.2);
+      ack.setTp(1.3);
+      ack.setExpectedRr(2.0);
+      ack.setUniqHash("abc");
+      ack.setSignalPayloadJson("{\"foo\":\"bar\"}");
+      ack.setCreatedAt(Instant.parse("2024-01-01T00:00:01Z"));
+
+      hub.broadcast(ack);
+
+      TestEmitter testEmitter = ref.get();
+      assertThat(testEmitter.events).isNotEmpty();
+      assertThat(testEmitter.events.get(0)).isEqualTo("hello");
+      assertThat(testEmitter.events).contains("trade");
+      int tradeIndex = testEmitter.events.lastIndexOf("trade");
+      Object tradeData = testEmitter.data.get(tradeIndex);
+      assertThat(tradeData).isInstanceOf(Map.class);
+      @SuppressWarnings("unchecked")
+      Map<String, Object> payload = (Map<String, Object>) tradeData;
+      assertThat(payload.get("strategyId")).isEqualTo("strategy-x");
+      assertThat(payload.get("payload")).isInstanceOf(Map.class);
+    } finally {
+      hub.shutdown();
+    }
+  }
+
+  private static class TestEmitter extends SseEmitter {
+    private final List<String> events = new ArrayList<>();
+    private final List<Object> data = new ArrayList<>();
+
+    TestEmitter() {
+      super(0L);
+    }
+
+    @Override
+    public synchronized void send(SseEventBuilder builder) throws IOException {
+      events.add((String) readField(builder, "name"));
+      data.add(readField(builder, "data"));
+    }
+
+    private Object readField(Object target, String fieldName) throws IOException {
+      try {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+      } catch (NoSuchFieldException e) {
+        return readFromSuperclass(target, fieldName);
+      } catch (IllegalAccessException e) {
+        throw new IOException("Cannot access field " + fieldName, e);
+      }
+    }
+
+    private Object readFromSuperclass(Object target, String fieldName) throws IOException {
+      Class<?> type = target.getClass().getSuperclass();
+      while (type != null) {
+        try {
+          Field field = type.getDeclaredField(fieldName);
+          field.setAccessible(true);
+          return field.get(target);
+        } catch (NoSuchFieldException ignored) {
+          type = type.getSuperclass();
+        } catch (IllegalAccessException e) {
+          throw new IOException("Cannot access field " + fieldName, e);
+        }
+      }
+      throw new IOException("Field " + fieldName + " not found");
+    }
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:livehub;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driverClassName: org.h2.Driver
+    username: sa
+    password: 
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+app:
+  live:
+    ingest:
+      hmacEnabled: false
+      hmacHeader: X-Live-Hmac
+      hmacSecretEnv: LIVE_HMAC_SECRET
+    sse:
+      heartbeatMillis: 60000


### PR DESCRIPTION
## Summary
- add live trade acknowledgement persistence, service layer, controller endpoints, and SSE hub with optional HMAC validation
- configure application properties, OpenAPI UI dependency, and README guidance for live ingest usage
- cover ingestion idempotence, recent retrieval, and SSE broadcasting with new tests and H2-backed test configuration

## Testing
- `mvn test` *(fails: missing com.ib:tws-api artifacts required by project dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_69055f9c431483238769ad769edfb3ad