### PR TITLE
Add Binance, Bitget, and Coinbase FX services

### DIFF
--- a/src/main/java/finance/project/api/controllers/AbstractFxController.java
+++ b/src/main/java/finance/project/api/controllers/AbstractFxController.java
@@ -1,0 +1,237 @@
+package finance.project.api.controllers;
+
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
+import finance.project.api.services.FxMarketDataService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Base REST controller exposing a common surface for FX market data providers.
+ */
+@ResponseBody
+public abstract class AbstractFxController {
+
+    private final FxMarketDataService service;
+
+    protected AbstractFxController(FxMarketDataService service) {
+        this.service = service;
+    }
+
+    protected FxMarketDataService getService() {
+        return service;
+    }
+
+    // --- Santé / statut ---
+    @GetMapping("/status")
+    public Map<String, Object> status() {
+        return Map.of(
+                "provider", service.getProvider(),
+                "connected", service.isConnected()
+        );
+    }
+
+    // --- Connexion / Déconnexion ---
+    @PostMapping("/connect")
+    public Map<String, Object> connect(
+            @RequestParam(defaultValue = "127.0.0.1") String host,
+            @RequestParam(defaultValue = "7497") int port,
+            @RequestParam(defaultValue = "1") int clientId
+    ) {
+        service.connect(host, port, clientId);
+        return Map.of(
+                "provider", service.getProvider(),
+                "connected", service.isConnected(),
+                "host", host,
+                "port", port,
+                "clientId", clientId
+        );
+    }
+
+    @PostMapping("/connect/wait")
+    public Map<String, Object> connectAndWait(
+            @RequestParam(defaultValue = "127.0.0.1") String host,
+            @RequestParam(defaultValue = "7497") int port,
+            @RequestParam(defaultValue = "1") int clientId,
+            @RequestParam(defaultValue = "3000") long timeoutMs
+    ) {
+        boolean ok = service.connectAndWait(host, port, clientId, timeoutMs);
+        return Map.of(
+                "provider", service.getProvider(),
+                "connected", ok,
+                "host", host,
+                "port", port,
+                "clientId", clientId,
+                "timeoutMs", timeoutMs
+        );
+    }
+
+    @PostMapping("/market-data-type")
+    public Map<String, Object> setMarketDataType(@RequestParam int type) {
+        ensureConnected();
+        if (!service.supportsMarketDataType()) {
+            return Map.of(
+                    "provider", service.getProvider(),
+                    "ok", false,
+                    "message", "Market data type switching is not supported for this provider"
+            );
+        }
+        service.setMarketDataType(type);
+        return Map.of(
+                "provider", service.getProvider(),
+                "ok", true,
+                "marketDataType", type,
+                "hint", "1=live,2=frozen,3=delayed,4=delayed-frozen"
+        );
+    }
+
+    @PostMapping("/disconnect")
+    public Map<String, Object> disconnect() {
+        service.disconnect();
+        return Map.of(
+                "provider", service.getProvider(),
+                "connected", service.isConnected()
+        );
+    }
+
+    // --- LIVE EUR/USD ---
+    @PostMapping("/live/eurusd/start")
+    public Map<String, Object> startLiveEurUsd() {
+        ensureConnected();
+        int reqId = service.startLiveEurUsd();
+        return Map.of(
+                "provider", service.getProvider(),
+                "reqId", reqId,
+                "message", "EURUSD live started"
+        );
+    }
+
+    @PostMapping("/live/stop/{reqId}")
+    public Map<String, Object> stopLive(@PathVariable int reqId) {
+        ensureConnected();
+        service.stopLive(reqId);
+        return Map.of(
+                "provider", service.getProvider(),
+                "reqId", reqId,
+                "message", "live stopped"
+        );
+    }
+
+    @GetMapping("/live/eurusd")
+    public List<FxQuote> recentLiveQuotes() {
+        return service.getRecentLiveQuotes();
+    }
+
+    // ---- LIVE BARS 1m EUR/USD ----
+    @PostMapping("/live/eurusd/1m/start")
+    public Map<String, Object> startLiveEurUsd1m() {
+        ensureConnected();
+        int reqId = service.startLiveMinuteBarsEurUsd();
+        return Map.of(
+                "provider", service.getProvider(),
+                "reqId", reqId,
+                "message", "EURUSD 1m bars live started"
+        );
+    }
+
+    @PostMapping("/live/bars/start")
+    public Map<String, Object> startLiveBars(
+            @RequestParam(defaultValue = "EURUSD") String pair,
+            @RequestParam(defaultValue = "1 D") String duration,
+            @RequestParam(defaultValue = "1 min") String barSize,
+            @RequestParam(defaultValue = "MIDPOINT") String what,
+            @RequestParam(defaultValue = "0") int rth,
+            @RequestParam(defaultValue = "2") int formatDate
+    ) {
+        ensureConnected();
+        int reqId = service.startLiveBars(pair, duration, barSize, what, rth, formatDate);
+        return Map.of(
+                "provider", service.getProvider(),
+                "reqId", reqId,
+                "pair", pair,
+                "duration", duration,
+                "barSize", barSize,
+                "what", what,
+                "rth", rth,
+                "formatDate", formatDate
+        );
+    }
+
+    @GetMapping("/live/bars/{reqId}")
+    public List<HistBar> recentLiveBars(@PathVariable int reqId) {
+        return service.getRecentLiveBars(reqId);
+    }
+
+    @GetMapping("/live/bars/{reqId}/last")
+    public HistBar getLastLiveBar(@PathVariable int reqId) {
+        return service.getLastLiveBar(reqId);
+    }
+
+    @PostMapping("/live/bars/stop/{reqId}")
+    public Map<String, Object> stopLiveBars(@PathVariable int reqId) {
+        ensureConnected();
+        service.stopLiveBars(reqId);
+        return Map.of(
+                "provider", service.getProvider(),
+                "reqId", reqId,
+                "stopped", true
+        );
+    }
+
+    // --- HISTORIQUE EUR/USD ---
+    @GetMapping("/hist/eurusd")
+    public List<HistBar> histEurUsd(
+            @RequestParam(defaultValue = "1 D") String duration,
+            @RequestParam(defaultValue = "1 min") String barSize
+    ) {
+        ensureConnected();
+        try {
+            return service.getHistoricalEurUsd(duration, barSize);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                    service.getProvider().toUpperCase() + " historical fetch failed: " + e.getMessage(), e);
+        }
+    }
+
+    protected void ensureConnected() {
+        if (!service.isConnected()) {
+            throw new ResponseStatusException(HttpStatus.PRECONDITION_FAILED,
+                    "Not connected to provider " + service.getProvider());
+        }
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> onError(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of(
+                        "provider", service.getProvider(),
+                        "error", e.getClass().getSimpleName(),
+                        "message", e.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(Throwable.class)
+    public ResponseEntity<Map<String, Object>> onAnyError(Throwable t) {
+        Throwable root = t;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return ResponseEntity.status(500).body(Map.of(
+                "provider", service.getProvider(),
+                "error", t.getClass().getName(),
+                "message", String.valueOf(t.getMessage()),
+                "rootError", root.getClass().getName(),
+                "rootMessage", String.valueOf(root.getMessage())
+        ));
+    }
+}

--- a/src/main/java/finance/project/api/controllers/BinanceController.java
+++ b/src/main/java/finance/project/api/controllers/BinanceController.java
@@ -1,0 +1,14 @@
+package finance.project.api.controllers;
+
+import finance.project.api.services.BinanceFxService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/binance")
+public class BinanceController extends AbstractFxController {
+
+    public BinanceController(BinanceFxService binanceFxService) {
+        super(binanceFxService);
+    }
+}

--- a/src/main/java/finance/project/api/controllers/BitgetController.java
+++ b/src/main/java/finance/project/api/controllers/BitgetController.java
@@ -1,0 +1,14 @@
+package finance.project.api.controllers;
+
+import finance.project.api.services.BitgetFxService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/bitget")
+public class BitgetController extends AbstractFxController {
+
+    public BitgetController(BitgetFxService bitgetFxService) {
+        super(bitgetFxService);
+    }
+}

--- a/src/main/java/finance/project/api/controllers/CoinbaseController.java
+++ b/src/main/java/finance/project/api/controllers/CoinbaseController.java
@@ -1,0 +1,14 @@
+package finance.project.api.controllers;
+
+import finance.project.api.services.CoinbaseFxService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/coinbase")
+public class CoinbaseController extends AbstractFxController {
+
+    public CoinbaseController(CoinbaseFxService coinbaseFxService) {
+        super(coinbaseFxService);
+    }
+}

--- a/src/main/java/finance/project/api/controllers/IbkrController.java
+++ b/src/main/java/finance/project/api/controllers/IbkrController.java
@@ -1,199 +1,26 @@
 package finance.project.api.controllers;
 
 import finance.project.api.services.IbkrFxService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/ibkr")
-public class IbkrController {
+public class IbkrController extends AbstractFxController {
 
-    private final IbkrFxService ib;
+    private final IbkrFxService ibkrService;
 
-    public IbkrController(IbkrFxService ib) {
-        this.ib = ib;
-    }
-
-    // --- Santé / statut ---
-    @GetMapping("/status")
-    public Map<String, Object> status() {
-        return Map.of(
-                "connected", ib.isConnected()
-        );
-    }
-
-    // --- Connexion / Déconnexion ---
-    @PostMapping("/connect")
-    public Map<String, Object> connect(
-            @RequestParam(defaultValue = "127.0.0.1") String host,
-            @RequestParam(defaultValue = "7497") int port,
-            @RequestParam(defaultValue = "1") int clientId
-    ) {
-        ib.connect(host, port, clientId);
-        return Map.of(
-                "connected", ib.isConnected(),
-                "host", host,
-                "port", port,
-                "clientId", clientId
-        );
-    }
-
-    @PostMapping("/connect/wait")
-    public Map<String,Object> connectAndWait(
-            @RequestParam(defaultValue="127.0.0.1") String host,
-            @RequestParam(defaultValue="7497") int port,
-            @RequestParam(defaultValue="1") int clientId,
-            @RequestParam(defaultValue="3000") long timeoutMs
-    ) {
-        boolean ok = ib.connectAndWait(host, port, clientId, timeoutMs);
-        return Map.of(
-                "connected", ok,
-                "host", host,
-                "port", port,
-                "clientId", clientId,
-                "timeoutMs", timeoutMs
-        );
+    public IbkrController(IbkrFxService ibkrService) {
+        super(ibkrService);
+        this.ibkrService = ibkrService;
     }
 
     @GetMapping("/diag")
     public Map<String, Object> diag() {
+        ensureConnected();
         return finance.project.api.bootstrap.IbkrRuntimeDiag.collect();
-    }
-
-    @PostMapping("/market-data-type")
-    public Map<String, Object> setMarketDataType(@RequestParam int type) {
-        ensureConnected();
-        ib.setMarketDataType(type);
-        return Map.of(
-                "ok", true,
-                "marketDataType", type,
-                "hint", "1=live,2=frozen,3=delayed,4=delayed-frozen"
-        );
-    }
-
-    @PostMapping("/disconnect")
-    public Map<String, Object> disconnect() {
-        ib.disconnect();
-        return Map.of("connected", ib.isConnected());
-    }
-
-    // --- LIVE EUR/USD ---
-    /** Démarre le flux Level 1 EURUSD (BID/ASK). Retourne le requestId. */
-    @PostMapping("/live/eurusd/start")
-    public Map<String, Object> startLiveEurUsd() {
-        ensureConnected();
-        int reqId = ib.startLiveEurUsd();
-        return Map.of("reqId", reqId, "message", "EURUSD live started");
-    }
-
-    /** Stoppe un flux live à partir du requestId. */
-    @PostMapping("/live/stop/{reqId}")
-    public Map<String, Object> stopLive(@PathVariable int reqId) {
-        ensureConnected();
-        ib.stopLive(reqId);
-        return Map.of("reqId", reqId, "message", "live stopped");
-    }
-
-    /** Récupère un snapshot (FIFO) des derniers ticks live bufferisés. */
-    @GetMapping("/live/eurusd")
-    public List<IbkrFxService.FxQuote> recentLiveQuotes() {
-        return ib.getRecentLiveQuotes();
-    }
-
-    // ---- LIVE BARS 1m EUR/USD ----
-
-    /** Démarre un flux de bougies 1 minute EURUSD (MIDPOINT). Retourne reqId. */
-    @PostMapping("/live/eurusd/1m/start")
-    public Map<String, Object> startLiveEurUsd1m() {
-        ensureConnected();
-        int reqId = ib.startLiveMinuteBarsEurUsd();
-        return Map.of("reqId", reqId, "message", "EURUSD 1m bars live started");
-    }
-
-    @PostMapping("/live/bars/start")
-    public Map<String,Object> startLiveBars(
-            @RequestParam(defaultValue = "EURUSD") String pair,
-            @RequestParam(defaultValue = "1 D") String duration,
-            @RequestParam(defaultValue = "1 min") String barSize,
-            @RequestParam(defaultValue = "MIDPOINT") String what,
-            @RequestParam(defaultValue = "0") int rth,
-            @RequestParam(defaultValue = "2") int formatDate  // 2 = epoch recommandé
-    ) {
-        ensureConnected();
-        int reqId = ib.startLiveBars(pair, duration, barSize, what, rth, formatDate);
-        return Map.of("reqId", reqId,
-                "pair", pair, "duration", duration, "barSize", barSize, "what", what, "rth", rth, "formatDate", formatDate);
-    }
-
-    /** Récupère les dernières bougies pour un flux donné (par reqId). */
-    @GetMapping("/live/bars/{reqId}")
-    public List<IbkrFxService.HistBar> recentLiveBars(@PathVariable int reqId) {
-        return ib.getRecentLiveBars(reqId);
-    }
-
-    @GetMapping("/live/bars/{reqId}/last")
-    public IbkrFxService.HistBar getLastLiveBar(@PathVariable int reqId) {
-        return ib.getLastLiveBar(reqId);
-    }
-
-
-
-    /** Stoppe le flux de bougies (par reqId). */
-    @PostMapping("/live/bars/stop/{reqId}")
-    public Map<String, Object> stopLiveBars(@PathVariable int reqId) {
-        ensureConnected();
-        ib.stopLiveBars(reqId);
-        return Map.of("reqId", reqId, "stopped", true);
-    }
-
-    // --- HISTORIQUE EUR/USD ---
-    /**
-     * Exemple : /ibkr/hist/eurusd?duration=1%20D&barSize=1%20min
-     * duration : "1 D", "1 W", "1 M", ...
-     * barSize : "1 min", "5 mins", "1 hour", ...
-     */
-    @GetMapping("/hist/eurusd")
-    public List<IbkrFxService.HistBar> histEurUsd(
-            @RequestParam(defaultValue = "1 D") String duration,
-            @RequestParam(defaultValue = "1 min") String barSize
-    ) {
-        ensureConnected();
-        try {
-            return ib.getHistoricalEurUsd(duration, barSize);
-        } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "IBKR historical fetch failed: " + e.getMessage(), e);
-        }
-    }
-
-    // --- Helper ---
-    private void ensureConnected() {
-        if (!ib.isConnected()) {
-            throw new ResponseStatusException(HttpStatus.PRECONDITION_FAILED, "Not connected to TWS/IB Gateway");
-        }
-    }
-
-    // (Optionnel) handler générique pour des erreurs non-captées
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> onError(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(Map.of("error", e.getClass().getSimpleName(), "message", e.getMessage()));
-    }
-
-    @ExceptionHandler(Throwable.class)
-    public ResponseEntity<Map<String, Object>> onAnyError(Throwable t) {
-        Throwable root = t;
-        while (root.getCause() != null && root.getCause() != root) root = root.getCause();
-        return ResponseEntity.status(500).body(Map.of(
-                "error", t.getClass().getName(),
-                "message", String.valueOf(t.getMessage()),
-                "rootError", root.getClass().getName(),
-                "rootMessage", String.valueOf(root.getMessage())
-        ));
     }
 }

--- a/src/main/java/finance/project/api/controllers/MexcController.java
+++ b/src/main/java/finance/project/api/controllers/MexcController.java
@@ -1,0 +1,14 @@
+package finance.project.api.controllers;
+
+import finance.project.api.services.MexcFxService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/mexc")
+public class MexcController extends AbstractFxController {
+
+    public MexcController(MexcFxService mexcFxService) {
+        super(mexcFxService);
+    }
+}

--- a/src/main/java/finance/project/api/model/fx/FxQuote.java
+++ b/src/main/java/finance/project/api/model/fx/FxQuote.java
@@ -1,0 +1,7 @@
+package finance.project.api.model.fx;
+
+/**
+ * Simple FX quote snapshot with bid/ask information.
+ */
+public record FxQuote(long tsMillis, double bid, double ask) {
+}

--- a/src/main/java/finance/project/api/model/fx/HistBar.java
+++ b/src/main/java/finance/project/api/model/fx/HistBar.java
@@ -1,0 +1,7 @@
+package finance.project.api.model.fx;
+
+/**
+ * Immutable OHLCV bar representation for FX style data.
+ */
+public record HistBar(long tsMillis, double open, double high, double low, double close, long volume) {
+}

--- a/src/main/java/finance/project/api/services/AbstractPollingFxService.java
+++ b/src/main/java/finance/project/api/services/AbstractPollingFxService.java
@@ -1,0 +1,384 @@
+package finance.project.api.services;
+
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Base implementation for FX market data services that rely on polling HTTP endpoints.
+ * It manages connection toggling, request identifiers, live quote/bar buffers and the
+ * scheduling of polling tasks. Concrete subclasses only need to supply provider specific
+ * HTTP calls and mapping logic.
+ */
+public abstract class AbstractPollingFxService implements FxMarketDataService {
+
+    private final String provider;
+    private final int liveQuoteBufferSize;
+    private final int liveBarsBufferSize;
+
+    protected final RestTemplate restTemplate = new RestTemplate();
+
+    private final ScheduledExecutorService scheduler;
+    private final Deque<FxQuote> liveQuotes;
+    private final ConcurrentHashMap<Integer, NavigableMap<Long, HistBar>> liveBars;
+    private final ConcurrentHashMap<Integer, ScheduledFuture<?>> liveQuoteTasks;
+    private final ConcurrentHashMap<Integer, ScheduledFuture<?>> liveBarTasks;
+    private final AtomicInteger reqId;
+
+    private volatile boolean connected;
+
+    protected AbstractPollingFxService(String provider) {
+        this(provider, 2_000, 3_000, 10_000);
+    }
+
+    protected AbstractPollingFxService(String provider, int liveQuoteBufferSize, int liveBarsBufferSize, int startingReqId) {
+        this.provider = provider;
+        this.liveQuoteBufferSize = liveQuoteBufferSize;
+        this.liveBarsBufferSize = liveBarsBufferSize;
+        this.scheduler = java.util.concurrent.Executors.newScheduledThreadPool(2, new ThreadFactory() {
+            private final AtomicInteger idx = new AtomicInteger();
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r, provider + "-fx-" + idx.incrementAndGet());
+                t.setDaemon(true);
+                return t;
+            }
+        });
+        this.liveQuotes = new ArrayDeque<>(liveQuoteBufferSize);
+        this.liveBars = new ConcurrentHashMap<>();
+        this.liveQuoteTasks = new ConcurrentHashMap<>();
+        this.liveBarTasks = new ConcurrentHashMap<>();
+        this.reqId = new AtomicInteger(startingReqId);
+    }
+
+    @Override
+    public String getProvider() {
+        return provider;
+    }
+
+    @Override
+    public synchronized void connect(String host, int port, int clientId) {
+        this.connected = true;
+    }
+
+    @Override
+    public synchronized boolean connectAndWait(String host, int port, int clientId, long timeoutMs) {
+        connect(host, port, clientId);
+        return connected;
+    }
+
+    @Override
+    public synchronized void disconnect() {
+        connected = false;
+        liveQuoteTasks.values().forEach(f -> f.cancel(true));
+        liveBarTasks.values().forEach(f -> f.cancel(true));
+        liveQuoteTasks.clear();
+        liveBarTasks.clear();
+        liveBars.clear();
+        synchronized (liveQuotes) {
+            liveQuotes.clear();
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
+    public int startLiveEurUsd() {
+        ensureConnected();
+        int id = nextReqId();
+        ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(
+                () -> fetchAndStoreQuote(defaultPair(), id),
+                0,
+                quotePollingIntervalSeconds(),
+                TimeUnit.SECONDS
+        );
+        liveQuoteTasks.put(id, future);
+        return id;
+    }
+
+    @Override
+    public void stopLive(int liveReqId) {
+        ScheduledFuture<?> future = liveQuoteTasks.remove(liveReqId);
+        if (future != null) {
+            future.cancel(true);
+        }
+    }
+
+    @Override
+    public List<FxQuote> getRecentLiveQuotes() {
+        synchronized (liveQuotes) {
+            return new ArrayList<>(liveQuotes);
+        }
+    }
+
+    @Override
+    public int startLiveMinuteBarsEurUsd() {
+        return startLiveBars(defaultPair(), "1 D", "1 min", "MIDPOINT", 0, 2);
+    }
+
+    @Override
+    public int startLiveBars(String pair, String duration, String barSize, String whatToShow, int useRth, int formatDate) {
+        ensureConnected();
+        Duration tfDuration = resolveBarSizeDuration(barSize);
+        if (tfDuration.isZero()) {
+            throw new IllegalArgumentException("Bar size duration resolved to zero for " + barSize);
+        }
+        String interval = mapBarSizeToInterval(barSize);
+        String symbol = normalizeSymbol(pair);
+
+        int id = nextReqId();
+        NavigableMap<Long, HistBar> buffer = new ConcurrentSkipListMap<>();
+        liveBars.put(id, buffer);
+
+        long pollingSeconds = liveBarsPollingIntervalSeconds(tfDuration);
+        ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(() -> pollBars(id, symbol, interval), 0, pollingSeconds, TimeUnit.SECONDS);
+        liveBarTasks.put(id, future);
+        return id;
+    }
+
+    @Override
+    public List<HistBar> getRecentLiveBars(int reqId) {
+        NavigableMap<Long, HistBar> map = liveBars.get(reqId);
+        if (map == null) {
+            return List.of();
+        }
+        synchronized (map) {
+            return new ArrayList<>(map.values());
+        }
+    }
+
+    @Override
+    public HistBar getLastLiveBar(int reqId) {
+        NavigableMap<Long, HistBar> map = liveBars.get(reqId);
+        if (map == null || map.isEmpty()) {
+            return null;
+        }
+        synchronized (map) {
+            return map.lastEntry().getValue();
+        }
+    }
+
+    @Override
+    public void stopLiveBars(int reqId) {
+        ScheduledFuture<?> future = liveBarTasks.remove(reqId);
+        if (future != null) {
+            future.cancel(true);
+        }
+        liveBars.remove(reqId);
+    }
+
+    @Override
+    public List<HistBar> getHistoricalEurUsd(String duration, String barSize) throws Exception {
+        ensureConnected();
+        Duration range = parseDuration(duration);
+        Duration tfDuration = resolveBarSizeDuration(barSize);
+        if (tfDuration.isZero()) {
+            throw new IllegalArgumentException("Bar size duration resolved to zero for " + barSize);
+        }
+        long bars = Math.max(1, range.getSeconds() / Math.max(1, tfDuration.getSeconds()));
+        bars = Math.min(bars, maxBarsPerRequest());
+        String interval = mapBarSizeToInterval(barSize);
+        String symbol = normalizeSymbol(defaultPair());
+        return fetchBars(symbol, interval, (int) bars);
+    }
+
+    protected void ensureConnected() {
+        if (!connected) {
+            throw new IllegalStateException(provider.toUpperCase(Locale.ROOT) + " service not connected");
+        }
+    }
+
+    protected int nextReqId() {
+        return reqId.getAndIncrement();
+    }
+
+    protected long quotePollingIntervalSeconds() {
+        return 2L;
+    }
+
+    protected long liveBarsPollingIntervalSeconds(Duration barSizeDuration) {
+        long seconds = barSizeDuration.getSeconds();
+        if (seconds <= 0) {
+            return 1L;
+        }
+        long half = Math.max(1L, seconds / 2);
+        return Math.min(seconds, half);
+    }
+
+    protected int liveBarsBufferSize() {
+        return liveBarsBufferSize;
+    }
+
+    protected String defaultPair() {
+        return "EURUSD";
+    }
+
+    protected String normalizeSymbol(String pair) {
+        if (pair == null) {
+            throw new IllegalArgumentException("Pair cannot be null");
+        }
+        return pair.replace("/", "").replace("-", "").trim().toUpperCase(Locale.ROOT);
+    }
+
+    protected Duration resolveBarSizeDuration(String barSize) {
+        ParsedTemporal parsed = parseTemporal(barSize);
+        return switch (parsed.unit) {
+            case SECOND -> Duration.ofSeconds(parsed.amount);
+            case MINUTE -> Duration.ofMinutes(parsed.amount);
+            case HOUR -> Duration.ofHours(parsed.amount);
+            case DAY -> Duration.ofDays(parsed.amount);
+            case WEEK -> Duration.ofDays(parsed.amount * 7L);
+            case MONTH -> Duration.ofDays(parsed.amount * 30L);
+        };
+    }
+
+    protected Duration parseDuration(String input) {
+        ParsedTemporal parsed = parseTemporal(input);
+        return switch (parsed.unit) {
+            case SECOND -> Duration.ofSeconds(parsed.amount);
+            case MINUTE -> Duration.ofMinutes(parsed.amount);
+            case HOUR -> Duration.ofHours(parsed.amount);
+            case DAY -> Duration.ofDays(parsed.amount);
+            case WEEK -> Duration.ofDays(parsed.amount * 7L);
+            case MONTH -> Duration.ofDays(parsed.amount * 30L);
+        };
+    }
+
+    protected ParsedTemporal parseTemporal(String input) {
+        if (input == null) {
+            throw new IllegalArgumentException("Temporal value cannot be null");
+        }
+        String trimmed = input.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Temporal value cannot be empty");
+        }
+        java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("(?i)^(\\d+)\\s*([a-z]+)$").matcher(trimmed);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException("Unsupported temporal format: " + input);
+        }
+        long amount = Long.parseLong(matcher.group(1));
+        String unitToken = matcher.group(2);
+        TemporalUnit unit = resolveUnit(unitToken);
+        return new ParsedTemporal(amount, unit);
+    }
+
+    protected TemporalUnit resolveUnit(String token) {
+        String normalized = token.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "s", "sec", "secs", "second", "seconds" -> TemporalUnit.SECOND;
+            case "m", "min", "mins", "minute", "minutes" -> TemporalUnit.MINUTE;
+            case "h", "hour", "hours" -> TemporalUnit.HOUR;
+            case "d", "day", "days" -> TemporalUnit.DAY;
+            case "w", "week", "weeks" -> TemporalUnit.WEEK;
+            case "mo", "mon", "mons", "month", "months" -> TemporalUnit.MONTH;
+            default -> {
+                if ("M".equals(token)) {
+                    yield TemporalUnit.MONTH;
+                }
+                throw new IllegalArgumentException("Unsupported unit token: " + token);
+            }
+        };
+    }
+
+    protected double parseDouble(Object value) {
+        if (value == null) {
+            return 0.0d;
+        }
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        return Double.parseDouble(value.toString());
+    }
+
+    protected int maxBarsPerRequest() {
+        return 1_000;
+    }
+
+    protected void handlePollingError(Exception e) {
+        e.printStackTrace();
+    }
+
+    private void fetchAndStoreQuote(String pair, int reqId) {
+        try {
+            FxQuote quote = fetchQuote(normalizeSymbol(pair));
+            if (quote == null) {
+                return;
+            }
+            synchronized (liveQuotes) {
+                if (liveQuotes.size() >= liveQuoteBufferSize) {
+                    liveQuotes.pollFirst();
+                }
+                liveQuotes.addLast(quote);
+            }
+        } catch (Exception e) {
+            handlePollingError(e);
+        }
+    }
+
+    private void pollBars(int id, String symbol, String interval) {
+        try {
+            List<HistBar> bars = fetchBars(symbol, interval, Math.min(liveBarsBufferSize, maxBarsPerRequest()));
+            if (bars == null || bars.isEmpty()) {
+                return;
+            }
+            bars.sort(java.util.Comparator.comparingLong(HistBar::tsMillis));
+            NavigableMap<Long, HistBar> map = liveBars.get(id);
+            if (map == null) {
+                return;
+            }
+            synchronized (map) {
+                for (HistBar bar : bars) {
+                    map.put(bar.tsMillis(), bar);
+                    while (map.size() > liveBarsBufferSize) {
+                        map.pollFirstEntry();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            handlePollingError(e);
+        }
+    }
+
+    protected abstract FxQuote fetchQuote(String normalizedSymbol) throws Exception;
+
+    protected abstract List<HistBar> fetchBars(String normalizedSymbol, String interval, int limit) throws Exception;
+
+    protected abstract String mapBarSizeToInterval(String barSize);
+
+    @PreDestroy
+    public void shutdown() {
+        scheduler.shutdownNow();
+    }
+
+    protected record ParsedTemporal(long amount, TemporalUnit unit) {
+    }
+
+    protected enum TemporalUnit {
+        SECOND,
+        MINUTE,
+        HOUR,
+        DAY,
+        WEEK,
+        MONTH
+    }
+}

--- a/src/main/java/finance/project/api/services/BinanceFxService.java
+++ b/src/main/java/finance/project/api/services/BinanceFxService.java
@@ -1,0 +1,105 @@
+package finance.project.api.services;
+
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class BinanceFxService extends AbstractPollingFxService {
+
+    @Value("${binance.api.url:https://api.binance.com/api/v3}")
+    private String binanceApiUrl;
+
+    public BinanceFxService() {
+        super("binance");
+    }
+
+    @Override
+    protected FxQuote fetchQuote(String normalizedSymbol) {
+        String url = UriComponentsBuilder.fromHttpUrl(binanceApiUrl + "/ticker/bookTicker")
+                .queryParam("symbol", normalizedSymbol)
+                .toUriString();
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+        Map<String, Object> body = response.getBody();
+        if (body == null || body.isEmpty()) {
+            return null;
+        }
+        double bid = parseDouble(body.get("bidPrice"));
+        double ask = parseDouble(body.get("askPrice"));
+        long now = Instant.now().toEpochMilli();
+        return new FxQuote(now, bid, ask);
+    }
+
+    @Override
+    protected List<HistBar> fetchBars(String normalizedSymbol, String interval, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, maxBarsPerRequest()));
+        String url = UriComponentsBuilder.fromHttpUrl(binanceApiUrl + "/klines")
+                .queryParam("symbol", normalizedSymbol)
+                .queryParam("interval", interval)
+                .queryParam("limit", safeLimit)
+                .toUriString();
+
+        ResponseEntity<List<List<Object>>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        List<List<Object>> body = response.getBody();
+        if (body == null || body.isEmpty()) {
+            return List.of();
+        }
+
+        List<HistBar> bars = new ArrayList<>(body.size());
+        for (List<Object> entry : body) {
+            long openTime = ((Number) entry.get(0)).longValue();
+            double open = parseDouble(entry.get(1));
+            double high = parseDouble(entry.get(2));
+            double low = parseDouble(entry.get(3));
+            double close = parseDouble(entry.get(4));
+            long volume = new BigDecimal(entry.get(5).toString()).longValue();
+            bars.add(new HistBar(openTime, open, high, low, close, volume));
+        }
+        return bars;
+    }
+
+    @Override
+    protected String mapBarSizeToInterval(String barSize) {
+        ParsedTemporal parsed = parseTemporal(barSize);
+        return switch (parsed.unit) {
+            case SECOND -> throw new IllegalArgumentException("Binance does not support second-level klines: " + barSize);
+            case MINUTE -> parsed.amount + "m";
+            case HOUR -> parsed.amount + "h";
+            case DAY -> parsed.amount + "d";
+            case WEEK -> parsed.amount + "w";
+            case MONTH -> parsed.amount + "M";
+        };
+    }
+
+    @Override
+    protected String normalizeSymbol(String pair) {
+        String normalized = super.normalizeSymbol(pair);
+        if (normalized.endsWith("USD") && !normalized.endsWith("USDT")) {
+            normalized = normalized.substring(0, normalized.length() - 3) + "USDT";
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/finance/project/api/services/BitgetFxService.java
+++ b/src/main/java/finance/project/api/services/BitgetFxService.java
@@ -1,0 +1,134 @@
+package finance.project.api.services;
+
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class BitgetFxService extends AbstractPollingFxService {
+
+    @Value("${bitget.api.url:https://api.bitget.com/api/v2}")
+    private String bitgetApiUrl;
+
+    public BitgetFxService() {
+        super("bitget");
+    }
+
+    @Override
+    protected FxQuote fetchQuote(String normalizedSymbol) {
+        String url = UriComponentsBuilder.fromHttpUrl(bitgetApiUrl + "/spot/market/ticker")
+                .queryParam("symbol", normalizedSymbol)
+                .toUriString();
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+        Map<String, Object> body = response.getBody();
+        if (body == null) {
+            return null;
+        }
+        Object dataObj = body.get("data");
+        if (!(dataObj instanceof List<?> dataList) || dataList.isEmpty()) {
+            return null;
+        }
+        Object first = dataList.get(0);
+        if (!(first instanceof Map<?, ?> ticker)) {
+            return null;
+        }
+        double bid = parseDouble(ticker.get("bestBid"));
+        if (bid == 0.0d) {
+            bid = parseDouble(ticker.get("bidPx"));
+        }
+        double ask = parseDouble(ticker.get("bestAsk"));
+        if (ask == 0.0d) {
+            ask = parseDouble(ticker.get("askPx"));
+        }
+        long timestamp = body.containsKey("requestTime")
+                ? ((Number) body.get("requestTime")).longValue()
+                : Instant.now().toEpochMilli();
+        return new FxQuote(timestamp, bid, ask);
+    }
+
+    @Override
+    protected List<HistBar> fetchBars(String normalizedSymbol, String interval, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, maxBarsPerRequest()));
+        String url = UriComponentsBuilder.fromHttpUrl(bitgetApiUrl + "/spot/market/candles")
+                .queryParam("symbol", normalizedSymbol)
+                .queryParam("granularity", interval)
+                .queryParam("limit", safeLimit)
+                .toUriString();
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        Map<String, Object> body = response.getBody();
+        if (body == null) {
+            return List.of();
+        }
+        Object dataObj = body.get("data");
+        if (!(dataObj instanceof List<?> rawBars) || rawBars.isEmpty()) {
+            return List.of();
+        }
+
+        List<HistBar> bars = new ArrayList<>(rawBars.size());
+        for (Object entryObj : rawBars) {
+            if (!(entryObj instanceof List<?> entry) || entry.size() < 6) {
+                continue;
+            }
+            long openTime = (long) (Double.parseDouble(entry.get(0).toString()) * 1000L);
+            double open = parseDouble(entry.get(1));
+            double high = parseDouble(entry.get(2));
+            double low = parseDouble(entry.get(3));
+            double close = parseDouble(entry.get(4));
+            long volume = new BigDecimal(entry.get(5).toString()).longValue();
+            bars.add(new HistBar(openTime, open, high, low, close, volume));
+        }
+        return bars;
+    }
+
+    @Override
+    protected String mapBarSizeToInterval(String barSize) {
+        ParsedTemporal parsed = parseTemporal(barSize);
+        long seconds = switch (parsed.unit) {
+            case SECOND -> parsed.amount;
+            case MINUTE -> parsed.amount * 60L;
+            case HOUR -> parsed.amount * 3_600L;
+            case DAY -> parsed.amount * 86_400L;
+            case WEEK -> parsed.amount * 604_800L;
+            case MONTH -> parsed.amount * 2_592_000L;
+        };
+        return Long.toString(seconds);
+    }
+
+    @Override
+    protected String normalizeSymbol(String pair) {
+        String normalized = super.normalizeSymbol(pair);
+        if (normalized.endsWith("USD") && !normalized.endsWith("USDT")) {
+            normalized = normalized.substring(0, normalized.length() - 3) + "USDT";
+        }
+        return normalized;
+    }
+
+    @Override
+    protected int maxBarsPerRequest() {
+        return 500;
+    }
+}

--- a/src/main/java/finance/project/api/services/CoinbaseFxService.java
+++ b/src/main/java/finance/project/api/services/CoinbaseFxService.java
@@ -1,0 +1,134 @@
+package finance.project.api.services;
+
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class CoinbaseFxService extends AbstractPollingFxService {
+
+    private static final Set<Long> ALLOWED_GRANULARITIES = Set.of(60L, 300L, 900L, 3_600L, 21_600L, 86_400L);
+
+    @Value("${coinbase.api.url:https://api.exchange.coinbase.com}")
+    private String coinbaseApiUrl;
+
+    public CoinbaseFxService() {
+        super("coinbase");
+    }
+
+    @Override
+    protected FxQuote fetchQuote(String normalizedSymbol) {
+        String url = UriComponentsBuilder.fromHttpUrl(coinbaseApiUrl + "/products/" + normalizedSymbol + "/ticker")
+                .toUriString();
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+        Map<String, Object> body = response.getBody();
+        if (body == null || body.isEmpty()) {
+            return null;
+        }
+        double bid = parseDouble(body.get("bid"));
+        double ask = parseDouble(body.get("ask"));
+        if (bid == 0.0d && body.containsKey("price")) {
+            bid = parseDouble(body.get("price"));
+        }
+        if (ask == 0.0d) {
+            ask = bid;
+        }
+        long timestamp;
+        Object time = body.get("time");
+        if (time instanceof String timeStr) {
+            timestamp = Instant.parse(timeStr).toEpochMilli();
+        } else {
+            timestamp = Instant.now().toEpochMilli();
+        }
+        return new FxQuote(timestamp, bid, ask);
+    }
+
+    @Override
+    protected List<HistBar> fetchBars(String normalizedSymbol, String interval, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, maxBarsPerRequest()));
+        String url = UriComponentsBuilder.fromHttpUrl(coinbaseApiUrl + "/products/" + normalizedSymbol + "/candles")
+                .queryParam("granularity", interval)
+                .queryParam("limit", safeLimit)
+                .toUriString();
+
+        ResponseEntity<List<List<Object>>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        List<List<Object>> body = response.getBody();
+        if (body == null || body.isEmpty()) {
+            return List.of();
+        }
+
+        List<HistBar> bars = new ArrayList<>(body.size());
+        for (List<Object> entry : body) {
+            if (entry.size() < 6) {
+                continue;
+            }
+            long openTime = ((Number) entry.get(0)).longValue() * 1000L;
+            double low = parseDouble(entry.get(1));
+            double high = parseDouble(entry.get(2));
+            double open = parseDouble(entry.get(3));
+            double close = parseDouble(entry.get(4));
+            long volume = new BigDecimal(entry.get(5).toString()).longValue();
+            bars.add(new HistBar(openTime, open, high, low, close, volume));
+        }
+        return bars;
+    }
+
+    @Override
+    protected String mapBarSizeToInterval(String barSize) {
+        ParsedTemporal parsed = parseTemporal(barSize);
+        long seconds = switch (parsed.unit) {
+            case SECOND -> parsed.amount;
+            case MINUTE -> parsed.amount * 60L;
+            case HOUR -> parsed.amount * 3_600L;
+            case DAY -> parsed.amount * 86_400L;
+            case WEEK -> parsed.amount * 604_800L;
+            case MONTH -> parsed.amount * 2_592_000L;
+        };
+        if (!ALLOWED_GRANULARITIES.contains(seconds)) {
+            throw new IllegalArgumentException("Coinbase granularity not supported: " + barSize + " -> " + seconds + " seconds");
+        }
+        return Long.toString(seconds);
+    }
+
+    @Override
+    protected String normalizeSymbol(String pair) {
+        if (pair == null) {
+            throw new IllegalArgumentException("Pair cannot be null");
+        }
+        String sanitized = pair.trim().toUpperCase(Locale.ROOT).replace("/", "-");
+        if (!sanitized.contains("-") && sanitized.length() >= 6) {
+            sanitized = sanitized.substring(0, 3) + "-" + sanitized.substring(3);
+        }
+        return sanitized;
+    }
+
+    @Override
+    protected int maxBarsPerRequest() {
+        return 300;
+    }
+}

--- a/src/main/java/finance/project/api/services/FxMarketDataService.java
+++ b/src/main/java/finance/project/api/services/FxMarketDataService.java
@@ -1,0 +1,73 @@
+package finance.project.api.services;
+
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
+
+import java.util.List;
+
+/**
+ * Common contract for FX market data providers so that controllers can share the same logic
+ * independently of the underlying broker or exchange implementation.
+ */
+public interface FxMarketDataService {
+
+    /**
+     * Identifier used for log messages or responses.
+     */
+    String getProvider();
+
+    /**
+     * Attempt to establish a connection to the underlying provider. Implementations that rely on
+     * HTTP polling can treat this as a logical toggle.
+     */
+    void connect(String host, int port, int clientId);
+
+    /**
+     * Connect and optionally wait for a handshake/ready signal.
+     *
+     * @return {@code true} if the provider is ready for use
+     */
+    boolean connectAndWait(String host, int port, int clientId, long timeoutMs);
+
+    /**
+     * Disconnect and release any associated resources.
+     */
+    void disconnect();
+
+    /**
+     * Indicates if the provider is currently connected/ready.
+     */
+    boolean isConnected();
+
+    /**
+     * Whether the provider supports switching market data type (live/delayed, etc.).
+     */
+    default boolean supportsMarketDataType() {
+        return false;
+    }
+
+    /**
+     * Update the market data type when supported.
+     */
+    default void setMarketDataType(int type) {
+        throw new UnsupportedOperationException("Market data type not supported for provider " + getProvider());
+    }
+
+    int startLiveEurUsd();
+
+    void stopLive(int liveReqId);
+
+    List<FxQuote> getRecentLiveQuotes();
+
+    int startLiveMinuteBarsEurUsd();
+
+    int startLiveBars(String pair, String duration, String barSize, String whatToShow, int useRth, int formatDate);
+
+    List<HistBar> getRecentLiveBars(int reqId);
+
+    HistBar getLastLiveBar(int reqId);
+
+    void stopLiveBars(int reqId);
+
+    List<HistBar> getHistoricalEurUsd(String duration, String barSize) throws Exception;
+}

--- a/src/main/java/finance/project/api/services/IbkrFxService.java
+++ b/src/main/java/finance/project/api/services/IbkrFxService.java
@@ -3,6 +3,8 @@ package finance.project.api.services;
 
 import com.ib.client.*;
 import finance.project.api.adapter.IbkrWrapperAdapter;
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -13,15 +15,8 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.ib.client.EWrapper;
-import com.ib.client.TickType;
-import com.ib.client.TickAttrib;
-import com.ib.client.TickAttribLast;
-import com.ib.client.TickAttribBidAsk;
-import com.ib.client.CommissionAndFeesReport;
-
 @Service
-public class IbkrFxService extends IbkrWrapperAdapter {
+public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataService {
 
     private CountDownLatch connectLatch;
 
@@ -64,8 +59,14 @@ public class IbkrFxService extends IbkrWrapperAdapter {
         this.client = new EClientSocket(this, signal);
     }
 
+    @Override
+    public String getProvider() {
+        return "ibkr";
+    }
+
 
     /** Connexion et attente du handshake (bloque jusqu’à timeout) */
+    @Override
     public synchronized boolean connectAndWait(String host, int port, int clientId, long timeoutMs) {
         if (client.isConnected()) return true;
 
@@ -118,12 +119,14 @@ public class IbkrFxService extends IbkrWrapperAdapter {
         }
     }
     /** Connexion async "fire-and-forget" (ne bloque pas) */
+    @Override
     public synchronized void connect(String host, int port, int clientId) {
         if (client.isConnected()) return;
         client.eConnect(host, port, clientId);
         startReaderIfNeeded();
     }
 
+    @Override
     public synchronized void disconnect() {
         try {
             if (client.isConnected()) client.eDisconnect();
@@ -136,6 +139,7 @@ public class IbkrFxService extends IbkrWrapperAdapter {
         }
     }
 
+    @Override
     public boolean isConnected() {
         return client.isConnected();
     }
@@ -143,6 +147,7 @@ public class IbkrFxService extends IbkrWrapperAdapter {
     /** ----------- LIVE FX EURUSD ----------- */
 
     /** Démarre un flux de bougies 1 minute (EURUSD MIDPOINT) en "keepUpToDate". */
+    @Override
     public int startLiveMinuteBarsEurUsd() {
         int id = reqId.getAndIncrement();
         liveBars.put(id, new ConcurrentSkipListMap<>());
@@ -166,6 +171,7 @@ public class IbkrFxService extends IbkrWrapperAdapter {
     }
 
     /** Démarre un flux de bougies paramétrable (keepUpToDate = true) */
+    @Override
     public int startLiveBars(String pair, String duration, String barSize, String whatToShow,
                              int useRth, int formatDate /*1=string,2=epoch*/) {
         validateBarSize(barSize);
@@ -201,12 +207,14 @@ public class IbkrFxService extends IbkrWrapperAdapter {
 
 
     /** Stoppe un flux live bars. */
+    @Override
     public void stopLiveBars(int barsReqId) {
         client.cancelHistoricalData(barsReqId);
         liveBars.remove(barsReqId);
     }
 
     /** (Optionnel) Récupère seulement la dernière bougie (pratique pour un front) */
+    @Override
     public HistBar getLastLiveBar(int reqId) {
         NavigableMap<Long, HistBar> map = liveBars.get(reqId);
         if (map == null || map.isEmpty()) return null;
@@ -214,6 +222,7 @@ public class IbkrFxService extends IbkrWrapperAdapter {
     }
 
     /** Snapshot des dernières bougies pour un flux donné. */
+    @Override
     public List<HistBar> getRecentLiveBars(int reqId) {
         NavigableMap<Long, HistBar> map = liveBars.get(reqId);
         if (map == null) return List.of();
@@ -239,6 +248,7 @@ public class IbkrFxService extends IbkrWrapperAdapter {
     }
 
     /** Démarre le flux live EURUSD (L1). */
+    @Override
     public int startLiveEurUsd() {
         int id = reqId.getAndIncrement();
         client.reqMktData(id, eurUsdCash(), "", false, false, null);
@@ -250,6 +260,12 @@ public class IbkrFxService extends IbkrWrapperAdapter {
         System.out.println("MDT reqId=" + reqId + " type=" + marketDataType);
     }
 
+    @Override
+    public boolean supportsMarketDataType() {
+        return true;
+    }
+
+    @Override
     public synchronized void setMarketDataType(int type) {
         if (type < 1 || type > 4) {
             throw new IllegalArgumentException("marketDataType must be 1,2,3,4");
@@ -261,11 +277,13 @@ public class IbkrFxService extends IbkrWrapperAdapter {
     }
 
     /** Arrête un flux live. */
+    @Override
     public void stopLive(int liveReqId) {
         client.cancelMktData(liveReqId);
     }
 
     /** Retourne un snapshot des derniers ticks live (thread-safe). */
+    @Override
     public synchronized List<FxQuote> getRecentLiveQuotes() {
         return new ArrayList<>(liveQuotes);
     }
@@ -278,6 +296,7 @@ public class IbkrFxService extends IbkrWrapperAdapter {
      * @param barSize     ex: "1 min", "5 mins", "1 hour"
      * @return            liste ordonnée de barres (chronologique)
      */
+    @Override
     public List<HistBar> getHistoricalEurUsd(String duration, String barSize) throws Exception {
         int id = reqId.getAndIncrement();
         CompletableFuture<List<HistBar>> fut = new CompletableFuture<>();
@@ -312,11 +331,6 @@ public class IbkrFxService extends IbkrWrapperAdapter {
         c.exchange("IDEALPRO");          // venue FX chez IB
         return c;
     }
-
-    /** ----------- DTOs ----------- */
-
-    public record FxQuote(long tsMillis, double bid, double ask) { }
-    public record HistBar(long tsMillis, double open, double high, double low, double close, long volume) { }
 
     /** ----------- EWrapper (callbacks) ----------- */
 

--- a/src/main/java/finance/project/api/services/MexcFxService.java
+++ b/src/main/java/finance/project/api/services/MexcFxService.java
@@ -1,0 +1,105 @@
+package finance.project.api.services;
+
+import finance.project.api.model.fx.FxQuote;
+import finance.project.api.model.fx.HistBar;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MexcFxService extends AbstractPollingFxService {
+
+    @Value("${mexc.api.url:https://api.mexc.com/api/v3}")
+    private String mexcApiUrl;
+
+    public MexcFxService() {
+        super("mexc");
+    }
+
+    @Override
+    protected FxQuote fetchQuote(String normalizedSymbol) {
+        String url = UriComponentsBuilder.fromHttpUrl(mexcApiUrl + "/ticker/bookTicker")
+                .queryParam("symbol", normalizedSymbol)
+                .toUriString();
+
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+        Map<String, Object> body = response.getBody();
+        if (body == null || body.isEmpty()) {
+            return null;
+        }
+        double bid = parseDouble(body.get("bidPrice"));
+        double ask = parseDouble(body.get("askPrice"));
+        long now = Instant.now().toEpochMilli();
+        return new FxQuote(now, bid, ask);
+    }
+
+    @Override
+    protected List<HistBar> fetchBars(String normalizedSymbol, String interval, int limit) {
+        int safeLimit = Math.max(1, Math.min(limit, maxBarsPerRequest()));
+        String url = UriComponentsBuilder.fromHttpUrl(mexcApiUrl + "/klines")
+                .queryParam("symbol", normalizedSymbol)
+                .queryParam("interval", interval)
+                .queryParam("limit", safeLimit)
+                .toUriString();
+
+        ResponseEntity<List<List<Object>>> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<>() {}
+        );
+
+        List<List<Object>> body = response.getBody();
+        if (body == null || body.isEmpty()) {
+            return List.of();
+        }
+
+        List<HistBar> bars = new ArrayList<>(body.size());
+        for (List<Object> entry : body) {
+            long openTime = ((Number) entry.get(0)).longValue();
+            double open = parseDouble(entry.get(1));
+            double high = parseDouble(entry.get(2));
+            double low = parseDouble(entry.get(3));
+            double close = parseDouble(entry.get(4));
+            long volume = new BigDecimal(entry.get(5).toString()).longValue();
+            bars.add(new HistBar(openTime, open, high, low, close, volume));
+        }
+        return bars;
+    }
+
+    @Override
+    protected String mapBarSizeToInterval(String barSize) {
+        ParsedTemporal parsed = parseTemporal(barSize);
+        return switch (parsed.unit) {
+            case SECOND -> throw new IllegalArgumentException("MEXC does not support second-level klines: " + barSize);
+            case MINUTE -> parsed.amount + "m";
+            case HOUR -> parsed.amount + "h";
+            case DAY -> parsed.amount + "d";
+            case WEEK -> parsed.amount + "w";
+            case MONTH -> parsed.amount + "M";
+        };
+    }
+
+    @Override
+    protected String normalizeSymbol(String pair) {
+        String normalized = super.normalizeSymbol(pair);
+        if (normalized.endsWith("USD") && !normalized.endsWith("USDT")) {
+            normalized = normalized.substring(0, normalized.length() - 3) + "USDT";
+        }
+        return normalized;
+    }
+}


### PR DESCRIPTION
## Summary
- extract polling-based FX market data behavior into AbstractPollingFxService and refactor the MEXC implementation on top of it
- add Binance, Bitget, and Coinbase FX services that reuse the shared polling scaffolding
- expose REST controllers for the new exchanges so they share the common FX controller surface

## Testing
- mvn -q -DskipTests package *(fails: missing com.ib TWS artifacts in Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_6905524477388323a64bf1440d819ecd