### PR TITLE
Refine asynchronous data import jobs in finance namespace

### DIFF
--- a/src/main/java/finance/project/api/Application.java
+++ b/src/main/java/finance/project/api/Application.java
@@ -4,8 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EntityScan({"finance.project.api.entities", "finance.project.api.dataimport"})
+@EnableJpaRepositories({"finance.project.api.repositories", "finance.project.api.dataimport"})
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/finance/project/api/Application.java
+++ b/src/main/java/finance/project/api/Application.java
@@ -9,8 +9,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@EntityScan({"finance.project.api.entities", "finance.project.api.dataimport"})
-@EnableJpaRepositories({"finance.project.api.repositories", "finance.project.api.dataimport"})
+@EntityScan({"finance.project.api.entities", "finance.project.api.dataimport", "finance.project.api.live"})
+@EnableJpaRepositories({"finance.project.api.repositories", "finance.project.api.dataimport", "finance.project.api.live"})
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/finance/project/api/dataimport/DataImportJob.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportJob.java
@@ -1,0 +1,213 @@
+package finance.project.api.dataimport;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "data_import_jobs")
+public class DataImportJob {
+
+    public enum Status {
+        PENDING,
+        RUNNING,
+        SUCCESS,
+        FAILED
+    }
+
+    @Id
+    @Column(nullable = false, updatable = false, length = 36)
+    private String id;
+
+    @Column(nullable = false, length = 50)
+    private String broker;
+
+    @Column(nullable = false, length = 100)
+    private String symbol;
+
+    @Column(nullable = false, length = 50)
+    private String timeframe;
+
+    @Column(length = 50)
+    private String venue;
+
+    @Column(length = 50)
+    private String timezone;
+
+    @Column(length = 50)
+    private String conflictPolicy;
+
+    @Column(length = 50)
+    private String rollover;
+
+    @Column(nullable = false)
+    private Instant startDate;
+
+    @Column(nullable = false)
+    private Instant endDate;
+
+    @Column(nullable = false, length = 20)
+    private String sourceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status;
+
+    @Column(nullable = false)
+    private int progress;
+
+    @Column(length = 500)
+    private String message;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getBroker() {
+        return broker;
+    }
+
+    public void setBroker(String broker) {
+        this.broker = broker;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public String getTimeframe() {
+        return timeframe;
+    }
+
+    public void setTimeframe(String timeframe) {
+        this.timeframe = timeframe;
+    }
+
+    public String getVenue() {
+        return venue;
+    }
+
+    public void setVenue(String venue) {
+        this.venue = venue;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public String getConflictPolicy() {
+        return conflictPolicy;
+    }
+
+    public void setConflictPolicy(String conflictPolicy) {
+        this.conflictPolicy = conflictPolicy;
+    }
+
+    public String getRollover() {
+        return rollover;
+    }
+
+    public void setRollover(String rollover) {
+        this.rollover = rollover;
+    }
+
+    public Instant getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(Instant startDate) {
+        this.startDate = startDate;
+    }
+
+    public Instant getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(Instant endDate) {
+        this.endDate = endDate;
+    }
+
+    public String getSourceType() {
+        return sourceType;
+    }
+
+    public void setSourceType(String sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
+
+    public void setProgress(int progress) {
+        this.progress = progress;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/DataImportJobRepository.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportJobRepository.java
@@ -1,0 +1,6 @@
+package finance.project.api.dataimport;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DataImportJobRepository extends JpaRepository<DataImportJob, String> {
+}

--- a/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
@@ -1,0 +1,207 @@
+package finance.project.api.dataimport;
+
+import finance.project.api.dataimport.ingestion.BinanceHistoricalService;
+import finance.project.api.dataimport.ingestion.CsvImportService;
+import finance.project.api.dataimport.ingestion.DatabentoCsvImportService;
+import finance.project.api.dataimport.ingestion.IbkrImportService;
+import finance.project.api.dataimport.ingestion.MexcHistoricalService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DataImportJobRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DataImportJobRunner.class);
+
+    private final DataImportJobRepository jobRepository;
+    private final BinanceHistoricalService binanceHistoricalService;
+    private final MexcHistoricalService mexcHistoricalService;
+    private final IbkrImportService ibkrImportService;
+    private final DatabentoCsvImportService databentoCsvImportService;
+    private final CsvImportService csvImportService;
+
+    public DataImportJobRunner(DataImportJobRepository jobRepository,
+                               BinanceHistoricalService binanceHistoricalService,
+                               MexcHistoricalService mexcHistoricalService,
+                               IbkrImportService ibkrImportService,
+                               DatabentoCsvImportService databentoCsvImportService,
+                               CsvImportService csvImportService) {
+        this.jobRepository = jobRepository;
+        this.binanceHistoricalService = binanceHistoricalService;
+        this.mexcHistoricalService = mexcHistoricalService;
+        this.ibkrImportService = ibkrImportService;
+        this.databentoCsvImportService = databentoCsvImportService;
+        this.csvImportService = csvImportService;
+    }
+
+    @Async("dataImportExecutor")
+    @Transactional
+    public void runJobAsync(String jobId) {
+        log.info("Dispatching data import job {}", jobId);
+        Optional<DataImportJob> jobOpt = jobRepository.findById(jobId);
+        if (jobOpt.isEmpty()) {
+            log.warn("Data import job {} not found", jobId);
+            return;
+        }
+
+        DataImportJob job = jobOpt.get();
+
+        try {
+            transitionToRunning(job);
+            executeJob(job);
+            markSuccess(job);
+        } catch (Exception e) {
+            log.error("Error while processing data import job {}", jobId, e);
+            markFailure(job, e);
+        }
+    }
+
+    private void executeJob(DataImportJob job) {
+        List<TimeRange> ranges;
+        if (isCsvJob(job)) {
+            ranges = new ArrayList<>();
+            ranges.add(new TimeRange(job.getStartDate(), job.getEndDate()));
+        } else {
+            ranges = splitIntoChunks(job.getStartDate(), job.getEndDate());
+            if (ranges.isEmpty()) {
+                ranges.add(new TimeRange(job.getStartDate(), job.getEndDate()));
+            }
+        }
+
+        int totalChunks = ranges.size();
+
+        log.info("Executing job {} across {} chunk(s)", job.getId(), totalChunks);
+        int processed = 0;
+        for (TimeRange range : ranges) {
+            processed++;
+            updateMessage(job, String.format("Téléchargement %d/%d", processed, totalChunks));
+            invokeBrokerImport(job, range);
+            updateProgress(job, processed, totalChunks);
+        }
+
+        updateMessage(job, "Insertion en base terminée");
+    }
+
+    private void invokeBrokerImport(DataImportJob job, TimeRange range) {
+        String broker = job.getBroker().toUpperCase();
+        String sourceType = job.getSourceType().toUpperCase();
+        Instant start = range.start();
+        Instant end = range.end();
+
+        switch (broker) {
+            case "BINANCE" -> binanceHistoricalService.fetchAndSave(job.getSymbol(), job.getTimeframe(), start, end);
+            case "MEXC" -> mexcHistoricalService.fetchAndSave(job.getSymbol(), job.getTimeframe(), start, end);
+            case "IBKR" -> ibkrImportService.fetchAndSave(job.getSymbol(), job.getTimeframe(), start, end);
+            case "DATABENTO_CSV" -> databentoCsvImportService.importCsv(
+                    job.getSymbol(), job.getTimeframe(), start, end, job.getVenue()
+            );
+            default -> {
+                if ("CSV".equals(sourceType)) {
+                    csvImportService.importGenericFile(broker, job.getSymbol(), job.getTimeframe(), start, end);
+                } else {
+                    log.warn("No dedicated handler for broker={} sourceType={} -> skipping chunk", broker, sourceType);
+                }
+            }
+        }
+    }
+
+    private void transitionToRunning(DataImportJob job) {
+        job.setStatus(DataImportJob.Status.RUNNING);
+        job.setProgress(0);
+        job.setMessage("Import en cours");
+        jobRepository.save(job);
+    }
+
+    private void updateMessage(DataImportJob job, String message) {
+        job.setMessage(message);
+        jobRepository.save(job);
+    }
+
+    private void updateProgress(DataImportJob job, int processed, int totalChunks) {
+        int progress = (int) Math.round(((double) processed / (double) totalChunks) * 90) + 10;
+        job.setProgress(Math.min(99, Math.max(progress, 10)));
+        jobRepository.save(job);
+    }
+
+    private void markSuccess(DataImportJob job) {
+        job.setStatus(DataImportJob.Status.SUCCESS);
+        job.setProgress(100);
+        job.setMessage("Import terminé");
+        jobRepository.save(job);
+    }
+
+    private void markFailure(DataImportJob job, Exception e) {
+        job.setStatus(DataImportJob.Status.FAILED);
+        job.setProgress(Math.min(job.getProgress(), 99));
+        job.setMessage(truncate("Erreur : " + e.getMessage()));
+        jobRepository.save(job);
+    }
+
+    private String truncate(String message) {
+        if (message == null) {
+            return null;
+        }
+        return message.length() > 250 ? message.substring(0, 250) : message;
+    }
+
+    private boolean isCsvJob(DataImportJob job) {
+        return job.getSourceType() != null && "CSV".equalsIgnoreCase(job.getSourceType());
+    }
+
+    private List<TimeRange> splitIntoChunks(Instant start, Instant end) {
+        List<TimeRange> ranges = new ArrayList<>();
+        if (start == null || end == null || !start.isBefore(end)) {
+            return ranges;
+        }
+
+        Duration total = Duration.between(start, end);
+        Duration step = determineChunkSize(total);
+        Instant cursor = start;
+        while (cursor.isBefore(end)) {
+            Instant next = cursor.plus(step);
+            if (!next.isAfter(end)) {
+                ranges.add(new TimeRange(cursor, next));
+            } else {
+                ranges.add(new TimeRange(cursor, end));
+            }
+            cursor = next;
+            if (!cursor.isBefore(end)) {
+                break;
+            }
+        }
+        return ranges;
+    }
+
+    private Duration determineChunkSize(Duration total) {
+        if (total.compareTo(Duration.ofDays(180)) > 0) {
+            return Duration.ofDays(30);
+        }
+        if (total.compareTo(Duration.ofDays(30)) > 0) {
+            return Duration.ofDays(7);
+        }
+        if (total.compareTo(Duration.ofDays(7)) > 0) {
+            return Duration.ofDays(1);
+        }
+        if (total.compareTo(Duration.ofHours(24)) > 0) {
+            return Duration.ofHours(12);
+        }
+        if (total.compareTo(Duration.ofHours(6)) > 0) {
+            return Duration.ofHours(6);
+        }
+        if (total.compareTo(Duration.ofHours(1)) > 0) {
+            return Duration.ofHours(1);
+        }
+        return Duration.ofMinutes(15);
+    }
+
+    private record TimeRange(Instant start, Instant end) {
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/DataImportService.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportService.java
@@ -1,0 +1,59 @@
+package finance.project.api.dataimport;
+
+import finance.project.api.dataimport.dto.DataImportRequest;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DataImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(DataImportService.class);
+
+    private final DataImportJobRepository jobRepository;
+    private final DataImportJobRunner jobRunner;
+
+    public DataImportService(DataImportJobRepository jobRepository, DataImportJobRunner jobRunner) {
+        this.jobRepository = jobRepository;
+        this.jobRunner = jobRunner;
+    }
+
+    @Transactional
+    public DataImportJob createJob(DataImportRequest req) {
+        Objects.requireNonNull(req, "DataImportRequest must not be null");
+
+        if (!req.startDate().isBefore(req.endDate())) {
+            throw new IllegalArgumentException("startDate must be before endDate");
+        }
+
+        DataImportJob job = new DataImportJob();
+        job.setId(UUID.randomUUID().toString());
+        job.setBroker(req.broker());
+        job.setSymbol(req.symbol());
+        job.setTimeframe(req.timeframe());
+        job.setVenue(req.venue());
+        job.setTimezone(req.timezone());
+        job.setConflictPolicy(req.conflictPolicy());
+        job.setRollover(req.rollover());
+        job.setStartDate(req.startDate());
+        job.setEndDate(req.endDate());
+        job.setSourceType(req.sourceType());
+        job.setStatus(DataImportJob.Status.PENDING);
+        job.setProgress(0);
+        job.setMessage(null);
+
+        log.info("Creating data import job {} for broker={} symbol={} timeframe={}", job.getId(), job.getBroker(), job.getSymbol(), job.getTimeframe());
+        jobRepository.save(job);
+
+        jobRunner.runJobAsync(job.getId());
+        return job;
+    }
+
+    public Optional<DataImportJob> getJob(String id) {
+        return jobRepository.findById(id);
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/api/DataImportJobController.java
+++ b/src/main/java/finance/project/api/dataimport/api/DataImportJobController.java
@@ -1,0 +1,41 @@
+package finance.project.api.dataimport.api;
+
+import finance.project.api.dataimport.DataImportJob;
+import finance.project.api.dataimport.DataImportService;
+import finance.project.api.dataimport.dto.DataImportJobResponse;
+import finance.project.api.dataimport.dto.DataImportRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/data-import/jobs")
+public class DataImportJobController {
+
+    private final DataImportService dataImportService;
+
+    public DataImportJobController(DataImportService dataImportService) {
+        this.dataImportService = dataImportService;
+    }
+
+    @PostMapping
+    public ResponseEntity<DataImportJobResponse> create(@RequestBody @Valid DataImportRequest request) {
+        DataImportJob job = dataImportService.createJob(request);
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(DataImportJobResponse.fromEntity(job));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<DataImportJobResponse> get(@PathVariable String id) {
+        return dataImportService.getJob(id)
+                .map(job -> ResponseEntity.ok(DataImportJobResponse.fromEntity(job)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/dto/DataImportJobResponse.java
+++ b/src/main/java/finance/project/api/dataimport/dto/DataImportJobResponse.java
@@ -1,0 +1,44 @@
+package finance.project.api.dataimport.dto;
+
+import finance.project.api.dataimport.DataImportJob;
+import java.time.Instant;
+
+public record DataImportJobResponse(
+        String id,
+        String broker,
+        String symbol,
+        String timeframe,
+        Instant startDate,
+        Instant endDate,
+        String sourceType,
+        String venue,
+        String timezone,
+        String conflictPolicy,
+        String rollover,
+        String status,
+        int progress,
+        String message,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static DataImportJobResponse fromEntity(DataImportJob job) {
+        return new DataImportJobResponse(
+                job.getId(),
+                job.getBroker(),
+                job.getSymbol(),
+                job.getTimeframe(),
+                job.getStartDate(),
+                job.getEndDate(),
+                job.getSourceType(),
+                job.getVenue(),
+                job.getTimezone(),
+                job.getConflictPolicy(),
+                job.getRollover(),
+                job.getStatus() != null ? job.getStatus().name() : null,
+                job.getProgress(),
+                job.getMessage(),
+                job.getCreatedAt(),
+                job.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/dto/DataImportRequest.java
+++ b/src/main/java/finance/project/api/dataimport/dto/DataImportRequest.java
@@ -1,0 +1,28 @@
+package finance.project.api.dataimport.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+
+public record DataImportRequest(
+        @NotBlank String broker,
+        @NotBlank String symbol,
+        @NotBlank String timeframe,
+        @NotNull Instant startDate,
+        @NotNull Instant endDate,
+        @NotBlank String sourceType,
+        String venue,
+        String timezone,
+        String conflictPolicy,
+        String rollover
+) {
+
+    @AssertTrue(message = "startDate must be before endDate")
+    public boolean isValidDateRange() {
+        if (startDate == null || endDate == null) {
+            return false;
+        }
+        return startDate.isBefore(endDate);
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/infrastructure/async/AsyncConfig.java
+++ b/src/main/java/finance/project/api/dataimport/infrastructure/async/AsyncConfig.java
@@ -1,0 +1,23 @@
+package finance.project.api.dataimport.infrastructure.async;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "dataImportExecutor")
+    public Executor dataImportExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("data-import-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/ingestion/BinanceHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/BinanceHistoricalService.java
@@ -1,0 +1,84 @@
+package finance.project.api.dataimport.ingestion;
+
+import finance.project.api.enums.MarketType;
+import finance.project.api.model.CandleDTO;
+import finance.project.api.services.BinanceService;
+import finance.project.api.services.CandleAggregationService;
+import finance.project.api.services.CandleService;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BinanceHistoricalService {
+
+    private static final List<String> TARGET_TIMEFRAMES = List.of(
+            "1min", "3min", "5min", "10min", "15min", "30min",
+            "1h", "2h", "4h", "8h", "12h", "daily", "weekly", "monthly"
+    );
+
+    private final BinanceService binanceService;
+    private final CandleService candleService;
+    private final CandleAggregationService candleAggregationService;
+
+    public void fetchAndSave(String symbol, String timeframe, Instant start, Instant end) {
+        LocalDateTime startUtc = LocalDateTime.ofInstant(start, ZoneOffset.UTC);
+        LocalDateTime endUtc = LocalDateTime.ofInstant(end, ZoneOffset.UTC);
+        log.info("[Binance] Import {} {} from {} to {}", symbol, timeframe, startUtc, endUtc);
+
+        List<CandleDTO> candles = binanceService.getHistoricalCandlesInRange(symbol, timeframe, startUtc, endUtc);
+        if (candles.isEmpty()) {
+            log.warn("[Binance] No candles returned for {} {} between {} and {}", symbol, timeframe, startUtc, endUtc);
+            return;
+        }
+
+        candleService.saveCandlesToDatabase(candles, symbol, timeframe);
+
+        String normalizedSource = normalizeTimeframe(timeframe);
+        for (String target : TARGET_TIMEFRAMES) {
+            if (target.equalsIgnoreCase(normalizedSource)) {
+                continue;
+            }
+            try {
+                List<CandleDTO> aggregated = candleAggregationService.aggregateCandles(candles, target, MarketType.CRYPTO);
+                if (aggregated.isEmpty()) {
+                    log.debug("[Binance] No aggregated candles produced for timeframe {}", target);
+                    continue;
+                }
+                candleService.saveCandlesToDatabase(aggregated, symbol, target);
+            } catch (IllegalArgumentException ex) {
+                log.warn("[Binance] Timeframe {} not supported for aggregation: {}", target, ex.getMessage());
+            }
+        }
+    }
+
+    private String normalizeTimeframe(String timeframe) {
+        if (timeframe == null) {
+            return "";
+        }
+        return switch (timeframe.toLowerCase()) {
+            case "1m" -> "1min";
+            case "3m" -> "3min";
+            case "5m" -> "5min";
+            case "10m" -> "10min";
+            case "15m" -> "15min";
+            case "30m" -> "30min";
+            case "1h", "60m" -> "1h";
+            case "2h", "120m" -> "2h";
+            case "4h", "240m" -> "4h";
+            case "6h", "360m" -> "6h";
+            case "8h", "480m" -> "8h";
+            case "12h", "720m" -> "12h";
+            case "1d", "daily" -> "daily";
+            case "1w", "weekly" -> "weekly";
+            case "1mo", "monthly" -> "monthly";
+            default -> timeframe.toLowerCase();
+        };
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/ingestion/CsvImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/CsvImportService.java
@@ -1,0 +1,17 @@
+package finance.project.api.dataimport.ingestion;
+
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CsvImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(CsvImportService.class);
+
+    public void importGenericFile(String broker, String symbol, String timeframe, Instant start, Instant end) {
+        log.info("[CSV] Importing broker={} symbol={} timeframe={} range={} -> {}", broker, symbol, timeframe, start, end);
+        // Integration point: wire CME, custom CSV loaders, and shared persistence flows here.
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportService.java
@@ -1,0 +1,71 @@
+package finance.project.api.dataimport.ingestion;
+
+import finance.project.api.enums.MarketType;
+import finance.project.api.model.CandleDTO;
+import finance.project.api.services.CandleAggregationService;
+import finance.project.api.services.CandleService;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DatabentoCsvImportService {
+
+    private static final List<String> TARGET_TIMEFRAMES = List.of(
+            "3min", "5min", "10min", "15min", "30min",
+            "1h", "2h", "4h", "8h", "12h", "daily", "weekly", "monthly"
+    );
+
+    private static final DateTimeFormatter DATASET_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM")
+            .withZone(ZoneOffset.UTC);
+
+    private final CandleService candleService;
+    private final CandleAggregationService candleAggregationService;
+
+    public void importCsv(String symbol, String timeframe, Instant start, Instant end, String datasetHint) {
+        String dataset = resolveDataset(start, datasetHint);
+        LocalDateTime startUtc = LocalDateTime.ofInstant(start, ZoneOffset.UTC);
+        LocalDateTime endUtc = LocalDateTime.ofInstant(end, ZoneOffset.UTC);
+        log.info("[Databento CSV] Import {} {} using dataset '{}' ({} to {})", symbol, timeframe, dataset, startUtc, endUtc);
+
+        List<CandleDTO> baseCandles = candleService.loadCsvCME(symbol, timeframe, dataset);
+        if (baseCandles.isEmpty()) {
+            log.warn("[Databento CSV] Dataset '{}' returned no candles for {} {}", dataset, symbol, timeframe);
+            return;
+        }
+
+        for (String target : TARGET_TIMEFRAMES) {
+            if (target.equalsIgnoreCase(timeframe)) {
+                continue;
+            }
+            try {
+                List<CandleDTO> aggregated = candleAggregationService.aggregateCandles(baseCandles, target, MarketType.CME);
+                if (aggregated.isEmpty()) {
+                    log.debug("[Databento CSV] No aggregated candles for timeframe {}", target);
+                    continue;
+                }
+                candleService.saveCandlesToDatabase(aggregated, symbol, target);
+            } catch (IllegalArgumentException ex) {
+                log.warn("[Databento CSV] Skipping timeframe {}: {}", target, ex.getMessage());
+            }
+        }
+    }
+
+    private String resolveDataset(Instant start, String datasetHint) {
+        if (StringUtils.hasText(datasetHint)) {
+            return datasetHint;
+        }
+        if (start == null) {
+            return "data_unknown";
+        }
+        return "data_" + DATASET_FORMATTER.format(start);
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
@@ -1,0 +1,17 @@
+package finance.project.api.dataimport.ingestion;
+
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IbkrImportService {
+
+    private static final Logger log = LoggerFactory.getLogger(IbkrImportService.class);
+
+    public void fetchAndSave(String symbol, String timeframe, Instant start, Instant end) {
+        log.info("[IBKR] Fetching candles for symbol={} timeframe={} range={} -> {}", symbol, timeframe, start, end);
+        // Integration point: call Interactive Brokers ingestion workflow when implemented.
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/ingestion/MexcHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/MexcHistoricalService.java
@@ -1,0 +1,17 @@
+package finance.project.api.dataimport.ingestion;
+
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MexcHistoricalService {
+
+    private static final Logger log = LoggerFactory.getLogger(MexcHistoricalService.class);
+
+    public void fetchAndSave(String symbol, String timeframe, Instant start, Instant end) {
+        log.info("[MEXC] Fetching candles for symbol={} timeframe={} range={} -> {}", symbol, timeframe, start, end);
+        // Integration point: call dedicated MEXC ingestion pipeline when available.
+    }
+}

--- a/src/main/java/finance/project/api/live/LiveTradeAckRepository.java
+++ b/src/main/java/finance/project/api/live/LiveTradeAckRepository.java
@@ -6,7 +6,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LiveTradeAckRepository extends JpaRepository<LiveTradeAck, Long> {
   Optional<LiveTradeAck> findByUniqHash(String uniqHash);
 

--- a/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
+++ b/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
@@ -1,0 +1,113 @@
+package finance.project.api.dataimport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import finance.project.api.dataimport.ingestion.BinanceHistoricalService;
+import finance.project.api.dataimport.ingestion.CsvImportService;
+import finance.project.api.dataimport.ingestion.DatabentoCsvImportService;
+import finance.project.api.dataimport.ingestion.IbkrImportService;
+import finance.project.api.dataimport.ingestion.MexcHistoricalService;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DataImportJobRunnerTest {
+
+    @Mock
+    private DataImportJobRepository jobRepository;
+
+    @Mock
+    private BinanceHistoricalService binanceHistoricalService;
+
+    @Mock
+    private MexcHistoricalService mexcHistoricalService;
+
+    @Mock
+    private IbkrImportService ibkrImportService;
+
+    @Mock
+    private DatabentoCsvImportService databentoCsvImportService;
+
+    @Mock
+    private CsvImportService csvImportService;
+
+    @InjectMocks
+    private DataImportJobRunner runner;
+
+    private DataImportJob job;
+
+    @BeforeEach
+    void setUp() {
+        job = new DataImportJob();
+        job.setId("job-123");
+        job.setBroker("BINANCE");
+        job.setSymbol("BTCUSDT");
+        job.setTimeframe("1h");
+        job.setStartDate(Instant.parse("2024-01-01T00:00:00Z"));
+        job.setEndDate(Instant.parse("2024-01-02T00:00:00Z"));
+        job.setSourceType("API");
+        job.setStatus(DataImportJob.Status.PENDING);
+        job.setProgress(0);
+    }
+
+    @Test
+    void runJobAsyncUpdatesJobToSuccess() {
+        when(jobRepository.findById("job-123")).thenReturn(Optional.of(job));
+        when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        doAnswer(invocation -> null)
+                .when(binanceHistoricalService)
+                .fetchAndSave(any(), any(), any(), any());
+
+        runner.runJobAsync("job-123");
+
+        assertThat(job.getStatus()).isEqualTo(DataImportJob.Status.SUCCESS);
+        assertThat(job.getProgress()).isEqualTo(100);
+        assertThat(job.getMessage()).isEqualTo("Import terminé");
+        verify(binanceHistoricalService).fetchAndSave(any(), any(), any(), any());
+    }
+
+    @Test
+    void runJobAsyncCapturesFailure() {
+        when(jobRepository.findById("job-123")).thenReturn(Optional.of(job));
+        when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doThrow(new IllegalStateException("network down"))
+                .when(binanceHistoricalService)
+                .fetchAndSave(any(), any(), any(), any());
+
+        runner.runJobAsync("job-123");
+
+        assertThat(job.getStatus()).isEqualTo(DataImportJob.Status.FAILED);
+        assertThat(job.getMessage()).contains("Erreur :");
+        assertThat(job.getProgress()).isLessThanOrEqualTo(99);
+    }
+
+    @Test
+    void csvJobDelegatesToDatabentoOnce() {
+        job.setBroker("DATABENTO_CSV");
+        job.setSourceType("CSV");
+        job.setVenue("data_2024-03");
+        job.setTimeframe("1min");
+        job.setStartDate(Instant.parse("2024-03-01T00:00:00Z"));
+        job.setEndDate(Instant.parse("2024-03-31T23:59:59Z"));
+
+        when(jobRepository.findById("job-123")).thenReturn(Optional.of(job));
+        when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        runner.runJobAsync("job-123");
+
+        verify(databentoCsvImportService)
+                .importCsv(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/finance/project/api/dataimport/DataImportServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/DataImportServiceTest.java
@@ -1,0 +1,117 @@
+package finance.project.api.dataimport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import finance.project.api.dataimport.dto.DataImportRequest;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DataImportServiceTest {
+
+    @Mock
+    private DataImportJobRepository jobRepository;
+
+    @Mock
+    private DataImportJobRunner jobRunner;
+
+    @InjectMocks
+    private DataImportService service;
+
+    @Test
+    void createJobPersistsAndTriggersRunner() {
+        DataImportRequest request = new DataImportRequest(
+                "BINANCE",
+                "BTCUSDT",
+                "1h",
+                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2024-01-02T00:00:00Z"),
+                "API",
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(jobRunner).runJobAsync(any());
+
+        DataImportJob job = service.createJob(request);
+
+        ArgumentCaptor<DataImportJob> captor = ArgumentCaptor.forClass(DataImportJob.class);
+        verify(jobRepository).save(captor.capture());
+        DataImportJob persisted = captor.getValue();
+
+        assertThat(job.getId()).isNotBlank();
+        assertThat(persisted.getStatus()).isEqualTo(DataImportJob.Status.PENDING);
+        assertThat(persisted.getProgress()).isZero();
+        verify(jobRunner).runJobAsync(eq(job.getId()));
+    }
+
+    @Test
+    void createJobCopiesOptionalMetadata() {
+        DataImportRequest request = new DataImportRequest(
+                "DATABENTO_CSV",
+                "EURUSD",
+                "1min",
+                Instant.parse("2024-03-01T00:00:00Z"),
+                Instant.parse("2024-03-31T23:59:59Z"),
+                "CSV",
+                "data_2024-03",
+                "UTC",
+                "merge",
+                "volume"
+        );
+
+        when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DataImportJob job = service.createJob(request);
+
+        assertThat(job.getVenue()).isEqualTo("data_2024-03");
+        assertThat(job.getTimezone()).isEqualTo("UTC");
+        assertThat(job.getConflictPolicy()).isEqualTo("merge");
+        assertThat(job.getRollover()).isEqualTo("volume");
+    }
+
+    @Test
+    void createJobWithInvalidRangeThrows() {
+        DataImportRequest request = new DataImportRequest(
+                "BINANCE",
+                "BTCUSDT",
+                "1h",
+                Instant.parse("2024-01-02T00:00:00Z"),
+                Instant.parse("2024-01-01T00:00:00Z"),
+                "API",
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertThatThrownBy(() -> service.createJob(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("startDate must be before endDate");
+    }
+
+    @Test
+    void getJobDelegatesToRepository() {
+        DataImportJob job = new DataImportJob();
+        job.setId("job-1");
+        when(jobRepository.findById("job-1")).thenReturn(Optional.of(job));
+
+        Optional<DataImportJob> result = service.getJob("job-1");
+        assertThat(result).isPresent();
+    }
+}


### PR DESCRIPTION
## Summary
- move the asynchronous data import module into the `finance.project.api` namespace and persist optional metadata for jobs and responses
- implement Binance and Databento ingestion services using the existing candle aggregation/saving flows while keeping CSV jobs single-chunk
- update configuration and tests to reflect the new package layout and cover metadata propagation and CSV dispatching

## Testing
- `./mvnw test` *(fails: missing com.ib:tws-api dependency in the existing build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8ab4440c832394cdbc3c45569aff)