### PR TITLE
Add Delta Lake exporter integration for market data imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ build/
 
 # Database Files
 sqlite.db
+local.duckdb
 database/*.db
 *.db
 /database/

--- a/MINIO.MD
+++ b/MINIO.MD
@@ -1,0 +1,27 @@
+Lancer MinIO :
+Dans un terminal
+cd C:\minio
+minio.exe server C:\minio\data --console-address ":9090"
+Par défaut (si non changé) :
+endpoint API : http://localhost:9000
+console UI : http://localhost:9090
+access key : minioadmin
+secret key : minioadmin
+
+Créer ton bucket :
+Dans http://localhost:9090 :
+login avec minioadmin / minioadmin
+crée un bucket : quant-delta-dev
+(optionnel) crée un dossier delta/ dedans pour être propre
+
+Créer une console duckdb et requeter:
+INSTALL delta;
+LOAD delta;
+SET s3_endpoint='http://127.0.0.1:9000';
+SET s3_access_key_id='minioadmin';
+SET s3_secret_access_key='minioadmin';
+SET s3_use_ssl=false;
+SET s3_url_style='path';
+SELECT *
+FROM delta_scan('s3://quant-delta-dev/delta/CRYPTO/SOLUSDT')
+LIMIT 50;

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,24 @@
 		<org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
 		<javafx.version>23</javafx.version>
 	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.ta4j</groupId>
+        <dependencies>
+                <dependency>
+                        <groupId>io.delta</groupId>
+                        <artifactId>delta-standalone_2.12</artifactId>
+                        <version>3.2.0</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-client</artifactId>
+                        <version>3.3.6</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.apache.parquet</groupId>
+                        <artifactId>parquet-avro</artifactId>
+                        <version>1.13.1</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.ta4j</groupId>
 			<artifactId>ta4j-core</artifactId>
 			<version>0.17</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,26 +31,67 @@
 		<org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
 		<javafx.version>23</javafx.version>
 	</properties>
-        <dependencies>
-                <dependency>
-                        <groupId>io.delta</groupId>
-                        <artifactId>delta-standalone_2.12</artifactId>
-                        <version>3.2.0</version>
-                </dependency>
-                <dependency>
-                        <groupId>org.apache.hadoop</groupId>
-                        <artifactId>hadoop-client</artifactId>
-                        <version>3.3.6</version>
-                </dependency>
-                <dependency>
-                        <groupId>org.apache.parquet</groupId>
-                        <artifactId>parquet-avro</artifactId>
-                        <version>1.13.1</version>
-                </dependency>
-                <dependency>
-                        <groupId>org.ta4j</groupId>
-			<artifactId>ta4j-core</artifactId>
-			<version>0.17</version>
+	<dependencies>
+		<dependency>
+				<groupId>io.delta</groupId>
+				<artifactId>delta-standalone_2.12</artifactId>
+				<version>3.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.duckdb</groupId>
+			<artifactId>duckdb_jdbc</artifactId>
+			<version>1.4.1.0</version>
+		</dependency>
+		<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-client</artifactId>
+				<version>3.3.6</version>
+				<exclusions>
+					<!-- Empêche un second binding SLF4J (reload4j) -->
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-reload4j</artifactId>
+					</exclusion>
+					<!-- Évite le vieux système commons-logging -->
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+					<!-- Sécurité si jamais un impl Log4j-SLF4J arrive par Hadoop -->
+					<exclusion>
+						<groupId>org.apache.logging.log4j</groupId>
+						<artifactId>log4j-slf4j2-impl</artifactId>
+					</exclusion>
+				</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-aws</artifactId>
+			<version>3.3.6</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-slf4j2-impl</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+				<groupId>org.apache.parquet</groupId>
+				<artifactId>parquet-avro</artifactId>
+				<version>1.13.1</version>
+		</dependency>
+		<dependency>
+				<groupId>org.ta4j</groupId>
+				<artifactId>ta4j-core</artifactId>
+				<version>0.17</version>
 		</dependency>
 		<!-- DEPENDANCES DE JAR IBKR -->
 		<dependency>
@@ -110,20 +151,20 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 		</dependency>
-                <dependency>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-starter-data-jpa</artifactId>
-                </dependency>
-                <dependency>
-                        <groupId>org.springdoc</groupId>
-                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-                        <version>2.6.0</version>
-                </dependency>
-                <dependency>
-                        <groupId>org.projectlombok</groupId>
-                        <artifactId>lombok</artifactId>
-                        <optional>true</optional>
-                </dependency>
+		<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+				<groupId>org.springdoc</groupId>
+				<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+				<version>2.6.0</version>
+		</dependency>
+		<dependency>
+				<groupId>org.projectlombok</groupId>
+				<artifactId>lombok</artifactId>
+				<optional>true</optional>
+		</dependency>
 		<!--
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/src/main/java/finance/project/api/bootstrap/MinioAutoLauncher.java
+++ b/src/main/java/finance/project/api/bootstrap/MinioAutoLauncher.java
@@ -1,0 +1,73 @@
+package finance.project.api.bootstrap;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class MinioAutoLauncher {
+
+    private static final String MINIO_PATH = "C:\\minio\\minio.exe";
+    private static final String DATA_PATH = "C:\\minio\\data";
+    private static final int MINIO_PORT = 9000;
+
+    private Process minioProcess;
+
+    @PostConstruct
+    public void startMinioIfNotRunning() {
+        if (!new File(MINIO_PATH).exists()) {
+            System.out.println("[MinIO] Skipping auto-start: " + MINIO_PATH + " not found");
+            return;
+        }
+
+        if (isPortOpen("localhost", MINIO_PORT)) {
+            System.out.println("[MinIO] Already running on port " + MINIO_PORT);
+            return;
+        }
+
+        System.out.println("[MinIO] Starting MinIO server...");
+        try {
+            ProcessBuilder pb = new ProcessBuilder(
+                    MINIO_PATH,
+                    "server", DATA_PATH,
+                    "--console-address", ":9090"
+            );
+            pb.directory(new File("C:\\minio"));
+            pb.inheritIO(); // affiche la sortie dans la console Spring Boot
+            minioProcess = pb.start();
+            Thread.sleep(4000); // petit délai pour qu'il démarre avant l'import
+            System.out.println("[MinIO] Launched successfully.");
+        } catch (IOException | InterruptedException e) {
+            System.err.println("[MinIO] Failed to start: " + e.getMessage());
+        }
+    }
+    /*
+    @PreDestroy
+    public void stopMinioOnExit() {
+        if (minioProcess != null && minioProcess.isAlive()) {
+            System.out.println("[MinIO] Stopping MinIO...");
+            minioProcess.destroy();
+            try {
+                if (!minioProcess.waitFor(3, TimeUnit.SECONDS)) {
+                    minioProcess.destroyForcibly();
+                }
+                System.out.println("[MinIO] Stopped.");
+            } catch (InterruptedException ignored) {}
+        }
+    }*/
+
+    private boolean isPortOpen(String host, int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(host, port), 1000);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/finance/project/api/config/DeltaLakeConfig.java
+++ b/src/main/java/finance/project/api/config/DeltaLakeConfig.java
@@ -1,0 +1,46 @@
+package finance.project.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Centralizes configuration for Delta Lake interactions.
+ */
+@Configuration
+public class DeltaLakeConfig {
+
+    private final String baseUri;
+
+    public DeltaLakeConfig(@Value("${delta.base-uri}") String baseUri) {
+        Assert.hasText(baseUri, "delta.base-uri must be configured");
+        this.baseUri = stripTrailingSlash(baseUri.trim());
+    }
+
+    public String getBaseUri() {
+        return baseUri;
+    }
+
+    public String resolveTablePath(String assetCategory, String symbol) {
+        Assert.hasText(assetCategory, "assetCategory must not be blank");
+        Assert.hasText(symbol, "symbol must not be blank");
+
+        String sanitizedCategory = sanitizeSegment(assetCategory);
+        String sanitizedSymbol = sanitizeSegment(symbol);
+
+        return baseUri + "/" + sanitizedCategory + "/" + sanitizedSymbol + "/";
+    }
+
+    private String sanitizeSegment(String value) {
+        String sanitized = StringUtils.trimAllWhitespace(value).replaceAll("[^a-zA-Z0-9_-]", "_");
+        return sanitized.isEmpty() ? "UNKNOWN" : sanitized.toUpperCase();
+    }
+
+    private String stripTrailingSlash(String value) {
+        if (value.endsWith("/")) {
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
@@ -120,15 +120,15 @@ public class DataImportJobRunner {
         Instant end = range.end();
 
         switch (broker) {
-            case "BINANCE" -> binanceHistoricalService.fetchAndSave(job.getSymbol(), job.getTimeframe(), start, end);
-            case "MEXC" -> mexcHistoricalService.fetchAndSave(job.getSymbol(), job.getTimeframe(), start, end);
-            case "IBKR" -> ibkrImportService.fetchAndSave(job.getSymbol(), job.getTimeframe(), start, end);
+            case "BINANCE" -> binanceHistoricalService.fetchAndSave(job, start, end);
+            case "MEXC" -> mexcHistoricalService.fetchAndSave(job, start, end);
+            case "IBKR" -> ibkrImportService.fetchAndSave(job, start, end);
             case "DATABENTO_CSV" -> databentoCsvImportService.importCsv(
-                    job.getSymbol(), job.getTimeframe(), start, end, job.getVenue()
+                    job, start, end, job.getVenue()
             );
             default -> {
                 if ("CSV".equals(sourceType)) {
-                    csvImportService.importGenericFile(broker, job.getSymbol(), job.getTimeframe(), start, end);
+                    csvImportService.importGenericFile(job, start, end);
                 } else {
                     log.warn("No dedicated handler for broker={} sourceType={} -> skipping chunk", broker, sourceType);
                 }

--- a/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
+++ b/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
@@ -1,0 +1,260 @@
+package finance.project.api.dataimport.infrastructure;
+
+import finance.project.api.config.DeltaLakeConfig;
+import finance.project.api.dataimport.DataImportJob;
+import finance.project.api.entities.Candle;
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Operation;
+import io.delta.standalone.OptimisticTransaction;
+import io.delta.standalone.actions.AddFile;
+import io.delta.standalone.actions.Action;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.types.DoubleType;
+import io.delta.standalone.types.LongType;
+import io.delta.standalone.types.StringType;
+import io.delta.standalone.types.StructField;
+import io.delta.standalone.types.StructType;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.util.HadoopOutputFile;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DeltaLakeExporter {
+
+    private static final Logger log = LoggerFactory.getLogger(DeltaLakeExporter.class);
+
+    private static final StructType CANDLE_SCHEMA = new StructType(new StructField[]{
+            new StructField("timestamp", new LongType(), false),
+            new StructField("open", new DoubleType(), true),
+            new StructField("high", new DoubleType(), true),
+            new StructField("low", new DoubleType(), true),
+            new StructField("close", new DoubleType(), true),
+            new StructField("volume", new DoubleType(), true),
+            new StructField("broker", new StringType(), true),
+            new StructField("sourceType", new StringType(), true),
+            new StructField("timeframe", new StringType(), true),
+            new StructField("symbol", new StringType(), true),
+            new StructField("jobId", new StringType(), true)
+    });
+
+    private static final Schema AVRO_SCHEMA = SchemaBuilder.record("candle")
+            .namespace("finance.project.delta")
+            .fields()
+            .name("timestamp").type().longType().noDefault()
+            .name("open").type().doubleType().noDefault()
+            .name("high").type().doubleType().noDefault()
+            .name("low").type().doubleType().noDefault()
+            .name("close").type().doubleType().noDefault()
+            .name("volume").type().unionOf().nullType().and().doubleType().endUnion().nullDefault()
+            .name("broker").type().stringType().noDefault()
+            .name("sourceType").type().stringType().noDefault()
+            .name("timeframe").type().stringType().noDefault()
+            .name("symbol").type().stringType().noDefault()
+            .name("jobId").type().stringType().noDefault()
+            .endRecord();
+
+    private final DeltaLakeConfig deltaLakeConfig;
+
+    public DeltaLakeExporter(DeltaLakeConfig deltaLakeConfig) {
+        this.deltaLakeConfig = deltaLakeConfig;
+    }
+
+    public void exportCandlesToDelta(DataImportJob job, List<Candle> candles) {
+        if (job == null) {
+            log.warn("[Delta] DataImportJob is null, skipping export");
+            return;
+        }
+        if (candles == null || candles.isEmpty()) {
+            log.debug("[Delta] No candles to export for job {}", job.getId());
+            return;
+        }
+
+        String assetCategory = resolveAssetCategory(job);
+        String tablePath = deltaLakeConfig.resolveTablePath(assetCategory, job.getSymbol());
+        String conflictPolicy = Optional.ofNullable(job.getConflictPolicy())
+                .map(policy -> policy.toUpperCase(Locale.ROOT))
+                .orElse("MERGE");
+
+        Configuration conf = createHadoopConfiguration();
+        try {
+            DeltaLog deltaLog = DeltaLog.forTable(conf, tablePath);
+
+            if ("SKIP".equals(conflictPolicy) && deltaLog.tableExists()) {
+                log.info("[Delta] Conflict policy=SKIP and table already exists at {}. Skipping export.", tablePath);
+                return;
+            }
+
+            OptimisticTransaction txn = deltaLog.startTransaction();
+
+            if (!deltaLog.tableExists()) {
+                Metadata metadata = Metadata.builder()
+                        .schema(CANDLE_SCHEMA)
+                        .name(job.getSymbol())
+                        .description("Candles for " + job.getSymbol())
+                        .build();
+                txn.updateMetadata(metadata);
+            }
+
+            List<Action> actions = new ArrayList<>();
+            if ("OVERWRITE".equals(conflictPolicy) && deltaLog.tableExists()) {
+                deltaLog.snapshot().getAllFiles().stream()
+                        .map(AddFile::remove)
+                        .forEach(actions::add);
+            }
+
+            Path tableRoot = new Path(tablePath);
+            Path dataDir = new Path(tableRoot, "data");
+            Path dataFile = new Path(dataDir, "part-" + UUID.randomUUID() + ".parquet");
+
+            writeParquet(conf, dataFile, job, candles);
+
+            FileSystem fs = dataFile.getFileSystem(conf);
+            FileStatus status = fs.getFileStatus(dataFile);
+            long fileSize = status.getLen();
+            String relativePath = relativize(tableRoot, dataFile);
+
+            AddFile addFile = new AddFile(
+                    relativePath,
+                    Collections.emptyMap(),
+                    fileSize,
+                    System.currentTimeMillis(),
+                    true,
+                    null,
+                    Collections.emptyMap()
+            );
+            actions.add(addFile);
+
+            Map<String, String> parameters = new HashMap<>();
+            parameters.put("mode", conflictPolicy);
+            parameters.put("assetCategory", assetCategory);
+            Operation operation = new Operation(Operation.Name.WRITE, parameters, Collections.emptyMap());
+
+            txn.commit(actions, operation, job.getId());
+            log.info("[Delta] Exported {} candles for job {} to {}", candles.size(), job.getId(), tablePath);
+        } catch (Exception e) {
+            log.error("[Delta] Failed to export candles for job {}: {}", job.getId(), e.getMessage(), e);
+        }
+    }
+
+    private void writeParquet(Configuration conf, Path dataFile, DataImportJob job, List<Candle> candles) throws IOException {
+        FileSystem fs = dataFile.getFileSystem(conf);
+        if (!fs.exists(dataFile.getParent())) {
+            fs.mkdirs(dataFile.getParent());
+        }
+
+        HadoopOutputFile outputFile = HadoopOutputFile.fromPath(dataFile, conf);
+        try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(outputFile)
+                .withSchema(AVRO_SCHEMA)
+                .withConf(conf)
+                .withCompressionCodec(CompressionCodecName.SNAPPY)
+                .build()) {
+            for (Candle candle : candles) {
+                if (candle == null || candle.getDate() == null) {
+                    continue;
+                }
+                GenericRecord record = new GenericData.Record(AVRO_SCHEMA);
+                record.put("timestamp", candle.getDate().toInstant(ZoneOffset.UTC).toEpochMilli());
+                record.put("open", asDouble(candle.getOpen()));
+                record.put("high", asDouble(candle.getHigh()));
+                record.put("low", asDouble(candle.getLow()));
+                record.put("close", asDouble(candle.getClose()));
+                record.put("volume", candle.getVolume() != null ? asDouble(candle.getVolume()) : null);
+                record.put("broker", defaultString(job.getBroker()));
+                record.put("sourceType", defaultString(job.getSourceType()));
+                record.put("timeframe", defaultString(job.getTimeframe()));
+                record.put("symbol", defaultString(job.getSymbol()));
+                record.put("jobId", defaultString(job.getId()));
+                writer.write(record);
+            }
+        }
+    }
+
+    private double asDouble(BigDecimal value) {
+        return value == null ? 0.0d : value.doubleValue();
+    }
+
+    private String defaultString(String value) {
+        return value == null ? "" : value;
+    }
+
+    private String relativize(Path tableRoot, Path filePath) {
+        String table = stripTrailingSlash(tableRoot.toUri().getPath());
+        String file = filePath.toUri().getPath();
+        if (file.startsWith(table)) {
+            String relative = file.substring(table.length());
+            if (relative.startsWith("/")) {
+                return relative.substring(1);
+            }
+            return relative;
+        }
+        return filePath.getName();
+    }
+
+    private String stripTrailingSlash(String value) {
+        if (value.endsWith("/")) {
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private Configuration createHadoopConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        configuration.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        configuration.set("fs.s3a.aws.credentials.provider", "com.amazonaws.auth.DefaultAWSCredentialsProviderChain");
+        configuration.setBoolean("fs.s3a.path.style.access", true);
+        return configuration;
+    }
+
+    private String resolveAssetCategory(DataImportJob job) {
+        if (job == null) {
+            return "ACTION";
+        }
+        if (job.getBroker() != null && job.getBroker().toUpperCase(Locale.ROOT).contains("CME")) {
+            return "CME";
+        }
+
+        String symbol = Optional.ofNullable(job.getSymbol()).orElse("").toUpperCase(Locale.ROOT);
+        if (symbol.endsWith("USDT") || symbol.endsWith("USDC") || symbol.endsWith("BTC")) {
+            return "CRYPTO";
+        }
+
+        String sourceType = Optional.ofNullable(job.getSourceType()).orElse("").toUpperCase(Locale.ROOT);
+        if (sourceType.contains("ETF")) {
+            return "ETF";
+        }
+        if (sourceType.contains("CFD") || symbol.contains("-CFD")) {
+            return "CFD";
+        }
+
+        if (sourceType.contains("FUTURE") || Optional.ofNullable(job.getVenue()).orElse("").toUpperCase(Locale.ROOT).contains("CME")) {
+            return "CME";
+        }
+
+        log.info("[Delta] Unable to classify asset for symbol={}, defaulting to ACTION", job.getSymbol());
+        return "ACTION";
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
+++ b/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
@@ -9,6 +9,7 @@ import io.delta.standalone.OptimisticTransaction;
 import io.delta.standalone.actions.AddFile;
 import io.delta.standalone.actions.Action;
 import io.delta.standalone.actions.Metadata;
+import io.delta.storage.LocalLogStore;
 import io.delta.standalone.types.DoubleType;
 import io.delta.standalone.types.LongType;
 import io.delta.standalone.types.StringType;
@@ -92,6 +93,7 @@ public class DeltaLakeExporter {
             return;
         }
 
+
         String assetCategory = resolveAssetCategory(job);
         String tablePath = deltaLakeConfig.resolveTablePath(assetCategory, job.getSymbol());
         String conflictPolicy = Optional.ofNullable(job.getConflictPolicy())
@@ -148,8 +150,8 @@ public class DeltaLakeExporter {
             actions.add(addFile);
 
             Map<String, String> parameters = new HashMap<>();
-            parameters.put("mode", conflictPolicy);
-            parameters.put("assetCategory", assetCategory);
+            parameters.put("mode", "\"" + conflictPolicy + "\"");
+            parameters.put("assetCategory", "\"" + assetCategory + "\"");
             Operation operation = new Operation(Operation.Name.WRITE, parameters, Collections.emptyMap());
 
             txn.commit(actions, operation, job.getId());
@@ -222,10 +224,40 @@ public class DeltaLakeExporter {
 
     private Configuration createHadoopConfiguration() {
         Configuration configuration = new Configuration();
+        // Impl S3A pour tous les chemins s3a://
         configuration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         configuration.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
-        configuration.set("fs.s3a.aws.credentials.provider", "com.amazonaws.auth.DefaultAWSCredentialsProviderChain");
+
+        // MinIO est sur localhost:9000
+        configuration.set("fs.s3a.endpoint", "http://localhost:9000");
         configuration.setBoolean("fs.s3a.path.style.access", true);
+        configuration.setBoolean("fs.s3a.connection.ssl.enabled", false);
+
+        // Credentials MinIO (DEV ONLY, à sortir plus tard dans la conf/env)
+        configuration.set("fs.s3a.access.key", "minioadmin");
+        configuration.set("fs.s3a.secret.key", "minioadmin");
+
+        // 🔴 CLÉ : éviter les fichiers temporaires sur disque => pas de NativeIO Windows
+        configuration.set("fs.s3a.fast.upload", "true");
+        configuration.set("fs.s3a.fast.upload.buffer", "array");
+        // (valides: disk, array, bytebuffer — on force array = mémoire pure)
+        // tu peux tuner un peu les tailles pour dev :
+        configuration.set("fs.s3a.block.size", "8m");
+        configuration.set("fs.s3a.multipart.size", "8m");
+        configuration.set("fs.s3a.multipart.threshold", "8m");
+
+        // Optionnel : répertoire tmp propre si jamais quelque chose en a besoin
+        configuration.set("hadoop.tmp.dir", "C:/hadoop-tmp");
+
+        //configuration.set("fs.defaultFS", "file:///");
+        //configuration.setBoolean("fs.permissions.umask-mode.ignore", true);
+        /*configuration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        configuration.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        configuration.set("fs.s3a.aws.credentials.provider", "com.amazonaws.auth.DefaultAWSCredentialsProviderChain");
+        configuration.setBoolean("fs.s3a.path.style.access", true);*/
+
+        // 🔐 Forcer l'utilisation de LocalLogStore pour le schéma file:
+        //configuration.set("spark.delta.logStore.file.impl", LocalLogStore.class.getName());
         return configuration;
     }
 

--- a/src/main/java/finance/project/api/dataimport/ingestion/BinanceHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/BinanceHistoricalService.java
@@ -1,10 +1,14 @@
 package finance.project.api.dataimport.ingestion;
 
+import finance.project.api.dataimport.DataImportJob;
+import finance.project.api.dataimport.infrastructure.DeltaLakeExporter;
+import finance.project.api.entities.Candle;
 import finance.project.api.enums.MarketType;
 import finance.project.api.model.CandleDTO;
 import finance.project.api.services.BinanceService;
 import finance.project.api.services.CandleAggregationService;
 import finance.project.api.services.CandleService;
+import finance.project.api.utils.TimeframeUtils;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -26,8 +30,11 @@ public class BinanceHistoricalService {
     private final BinanceService binanceService;
     private final CandleService candleService;
     private final CandleAggregationService candleAggregationService;
+    private final DeltaLakeExporter deltaLakeExporter;
 
-    public void fetchAndSave(String symbol, String timeframe, Instant start, Instant end) {
+    public void fetchAndSave(DataImportJob job, Instant start, Instant end) {
+        String symbol = job.getSymbol();
+        String timeframe = job.getTimeframe();
         LocalDateTime startUtc = LocalDateTime.ofInstant(start, ZoneOffset.UTC);
         LocalDateTime endUtc = LocalDateTime.ofInstant(end, ZoneOffset.UTC);
         log.info("[Binance] Import {} {} from {} to {}", symbol, timeframe, startUtc, endUtc);
@@ -39,6 +46,7 @@ public class BinanceHistoricalService {
         }
 
         candleService.saveCandlesToDatabase(candles, symbol, timeframe);
+        deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, timeframe));
 
         String normalizedSource = normalizeTimeframe(timeframe);
         for (String target : TARGET_TIMEFRAMES) {
@@ -56,6 +64,27 @@ public class BinanceHistoricalService {
                 log.warn("[Binance] Timeframe {} not supported for aggregation: {}", target, ex.getMessage());
             }
         }
+    }
+
+    private List<Candle> mapForDelta(List<CandleDTO> candles, String timeframe) {
+        List<Candle> entities = new java.util.ArrayList<>(candles.size());
+        String normalized = TimeframeUtils.mapToCustomTimeframe(timeframe);
+        for (CandleDTO dto : candles) {
+            if (dto == null) {
+                continue;
+            }
+            Candle candle = new Candle();
+            candle.setTimeframe(normalized);
+            candle.setDate(dto.getDate());
+            candle.setOpen(dto.getOpen());
+            candle.setClose(dto.getClose());
+            candle.setHigh(dto.getHigh());
+            candle.setLow(dto.getLow());
+            candle.setVolume(dto.getVolume());
+            candle.setSymbolFuture(dto.getSymbolFuture());
+            entities.add(candle);
+        }
+        return entities;
     }
 
     private String normalizeTimeframe(String timeframe) {

--- a/src/main/java/finance/project/api/dataimport/ingestion/CsvImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/CsvImportService.java
@@ -1,5 +1,6 @@
 package finance.project.api.dataimport.ingestion;
 
+import finance.project.api.dataimport.DataImportJob;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,8 +11,8 @@ public class CsvImportService {
 
     private static final Logger log = LoggerFactory.getLogger(CsvImportService.class);
 
-    public void importGenericFile(String broker, String symbol, String timeframe, Instant start, Instant end) {
-        log.info("[CSV] Importing broker={} symbol={} timeframe={} range={} -> {}", broker, symbol, timeframe, start, end);
+    public void importGenericFile(DataImportJob job, Instant start, Instant end) {
+        log.info("[CSV] Importing broker={} symbol={} timeframe={} range={} -> {}", job.getBroker(), job.getSymbol(), job.getTimeframe(), start, end);
         // Integration point: wire CME, custom CSV loaders, and shared persistence flows here.
     }
 }

--- a/src/main/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportService.java
@@ -1,9 +1,13 @@
 package finance.project.api.dataimport.ingestion;
 
+import finance.project.api.dataimport.DataImportJob;
+import finance.project.api.dataimport.infrastructure.DeltaLakeExporter;
+import finance.project.api.entities.Candle;
 import finance.project.api.enums.MarketType;
 import finance.project.api.model.CandleDTO;
 import finance.project.api.services.CandleAggregationService;
 import finance.project.api.services.CandleService;
+import finance.project.api.utils.TimeframeUtils;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -29,8 +33,11 @@ public class DatabentoCsvImportService {
 
     private final CandleService candleService;
     private final CandleAggregationService candleAggregationService;
+    private final DeltaLakeExporter deltaLakeExporter;
 
-    public void importCsv(String symbol, String timeframe, Instant start, Instant end, String datasetHint) {
+    public void importCsv(DataImportJob job, Instant start, Instant end, String datasetHint) {
+        String symbol = job.getSymbol();
+        String timeframe = job.getTimeframe();
         String dataset = resolveDataset(start, datasetHint);
         LocalDateTime startUtc = LocalDateTime.ofInstant(start, ZoneOffset.UTC);
         LocalDateTime endUtc = LocalDateTime.ofInstant(end, ZoneOffset.UTC);
@@ -41,6 +48,9 @@ public class DatabentoCsvImportService {
             log.warn("[Databento CSV] Dataset '{}' returned no candles for {} {}", dataset, symbol, timeframe);
             return;
         }
+
+        candleService.saveCandlesToDatabase(baseCandles, symbol, timeframe);
+        deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(baseCandles, timeframe));
 
         for (String target : TARGET_TIMEFRAMES) {
             if (target.equalsIgnoreCase(timeframe)) {
@@ -57,6 +67,27 @@ public class DatabentoCsvImportService {
                 log.warn("[Databento CSV] Skipping timeframe {}: {}", target, ex.getMessage());
             }
         }
+    }
+
+    private List<Candle> mapForDelta(List<CandleDTO> candles, String timeframe) {
+        List<Candle> entities = new java.util.ArrayList<>(candles.size());
+        String normalized = TimeframeUtils.mapToCustomTimeframe(timeframe);
+        for (CandleDTO dto : candles) {
+            if (dto == null) {
+                continue;
+            }
+            Candle candle = new Candle();
+            candle.setTimeframe(normalized);
+            candle.setDate(dto.getDate());
+            candle.setOpen(dto.getOpen());
+            candle.setClose(dto.getClose());
+            candle.setHigh(dto.getHigh());
+            candle.setLow(dto.getLow());
+            candle.setVolume(dto.getVolume());
+            candle.setSymbolFuture(dto.getSymbolFuture());
+            entities.add(candle);
+        }
+        return entities;
     }
 
     private String resolveDataset(Instant start, String datasetHint) {

--- a/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
@@ -1,5 +1,6 @@
 package finance.project.api.dataimport.ingestion;
 
+import finance.project.api.dataimport.DataImportJob;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,8 +11,8 @@ public class IbkrImportService {
 
     private static final Logger log = LoggerFactory.getLogger(IbkrImportService.class);
 
-    public void fetchAndSave(String symbol, String timeframe, Instant start, Instant end) {
-        log.info("[IBKR] Fetching candles for symbol={} timeframe={} range={} -> {}", symbol, timeframe, start, end);
+    public void fetchAndSave(DataImportJob job, Instant start, Instant end) {
+        log.info("[IBKR] Fetching candles for symbol={} timeframe={} range={} -> {}", job.getSymbol(), job.getTimeframe(), start, end);
         // Integration point: call Interactive Brokers ingestion workflow when implemented.
     }
 }

--- a/src/main/java/finance/project/api/dataimport/ingestion/MexcHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/MexcHistoricalService.java
@@ -1,5 +1,6 @@
 package finance.project.api.dataimport.ingestion;
 
+import finance.project.api.dataimport.DataImportJob;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,8 +11,8 @@ public class MexcHistoricalService {
 
     private static final Logger log = LoggerFactory.getLogger(MexcHistoricalService.class);
 
-    public void fetchAndSave(String symbol, String timeframe, Instant start, Instant end) {
-        log.info("[MEXC] Fetching candles for symbol={} timeframe={} range={} -> {}", symbol, timeframe, start, end);
+    public void fetchAndSave(DataImportJob job, Instant start, Instant end) {
+        log.info("[MEXC] Fetching candles for symbol={} timeframe={} range={} -> {}", job.getSymbol(), job.getTimeframe(), start, end);
         // Integration point: call dedicated MEXC ingestion pipeline when available.
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,3 +51,6 @@ nasdaq.api.key=zqNMxPjE-nTvSaba2jZz
 
 # Binance API URL (public)
 binance.api.url=https://api.binance.com/api/v3
+
+DELTA_BASE_URI=s3a://quant-delta-dev/delta
+#DELTA_BASE_URI=./delta-tables

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,5 @@ app:
       hmacSecretEnv: LIVE_HMAC_SECRET
     sse:
       heartbeatMillis: 15000
+delta:
+  base-uri: ${DELTA_BASE_URI:s3://my-bucket/delta}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,4 +7,5 @@ app:
     sse:
       heartbeatMillis: 15000
 delta:
-  base-uri: ${DELTA_BASE_URI:s3://my-bucket/delta}
+  #base-uri: ${DELTA_BASE_URI:./delta-tables}
+  base-uri: ${DELTA_BASE_URI:s3a://quant-delta-dev/delta}

--- a/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
+++ b/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
@@ -68,14 +68,14 @@ class DataImportJobRunnerTest {
 
         doAnswer(invocation -> null)
                 .when(binanceHistoricalService)
-                .fetchAndSave(any(), any(), any(), any());
+                .fetchAndSave(any(), any(), any());
 
         runner.runJobAsync("job-123");
 
         assertThat(job.getStatus()).isEqualTo(DataImportJob.Status.SUCCESS);
         assertThat(job.getProgress()).isEqualTo(100);
         assertThat(job.getMessage()).isEqualTo("Import terminé");
-        verify(binanceHistoricalService).fetchAndSave(any(), any(), any(), any());
+        verify(binanceHistoricalService).fetchAndSave(any(), any(), any());
     }
 
     @Test
@@ -84,7 +84,7 @@ class DataImportJobRunnerTest {
         when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
         doThrow(new IllegalStateException("network down"))
                 .when(binanceHistoricalService)
-                .fetchAndSave(any(), any(), any(), any());
+                .fetchAndSave(any(), any(), any());
 
         runner.runJobAsync("job-123");
 
@@ -108,6 +108,6 @@ class DataImportJobRunnerTest {
         runner.runJobAsync("job-123");
 
         verify(databentoCsvImportService)
-                .importCsv(any(), any(), any(), any(), any());
+                .importCsv(any(), any(), any(), any());
     }
 }


### PR DESCRIPTION
## Summary
- add a Delta Lake configuration bean that resolves S3 table paths from the new `delta.base-uri` property
- implement a reusable `DeltaLakeExporter` that writes imported candles into Delta tables with conflict policy handling
- integrate the exporter into the import pipeline, updating broker services and job runner signatures and adding Delta/Hadoop dependencies

## Testing
- `mvn -q -DskipTests compile` *(fails: missing cached com.ib:tws-api artifacts in Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fef3fbad483238d9dfb979ced2628)