### PR TITLE
Update Delta Lake path structure to include currency folders

### DIFF
--- a/src/main/java/finance/project/api/config/DeltaLakeConfig.java
+++ b/src/main/java/finance/project/api/config/DeltaLakeConfig.java
@@ -1,5 +1,7 @@
 package finance.project.api.config;
 
+import java.util.List;
+import java.util.Locale;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;
@@ -27,15 +29,47 @@ public class DeltaLakeConfig {
         Assert.hasText(symbol, "symbol must not be blank");
 
         String sanitizedCategory = sanitizeSegment(assetCategory);
-        String sanitizedSymbol = sanitizeSegment(symbol);
+        SymbolPathSegments segments = parseSymbolSegments(symbol);
 
-        return baseUri + "/" + sanitizedCategory + "/" + sanitizedSymbol + "/";
+        return baseUri + "/" + sanitizedCategory + "/" + segments.currency() + "/" + segments.baseSymbol() + "/";
+    }
+
+    private SymbolPathSegments parseSymbolSegments(String symbol) {
+        String trimmed = StringUtils.trimAllWhitespace(symbol).toUpperCase(Locale.ROOT);
+        if (trimmed.contains(":")) {
+            String[] parts = trimmed.split(":", 2);
+            return new SymbolPathSegments(sanitizeSegment(parts[0]), sanitizeSegment(parts[1]));
+        }
+        if (trimmed.contains("_")) {
+            String[] parts = trimmed.split("_", 2);
+            return new SymbolPathSegments(sanitizeSegment(parts[0]), sanitizeSegment(parts[1]));
+        }
+
+        String base = trimmed;
+        String currency = "UNKNOWN";
+        for (String quote : KNOWN_QUOTES) {
+            if (trimmed.endsWith(quote) && trimmed.length() > quote.length()) {
+                base = trimmed.substring(0, trimmed.length() - quote.length());
+                currency = quote;
+                break;
+            }
+        }
+
+        return new SymbolPathSegments(sanitizeSegment(base), sanitizeSegment(currency));
     }
 
     private String sanitizeSegment(String value) {
         String sanitized = StringUtils.trimAllWhitespace(value).replaceAll("[^a-zA-Z0-9_-]", "_");
         return sanitized.isEmpty() ? "UNKNOWN" : sanitized.toUpperCase();
     }
+
+    private record SymbolPathSegments(String baseSymbol, String currency) {}
+
+    private static final List<String> KNOWN_QUOTES = List.of(
+            "USDT", "USDC", "BTC", "ETH",
+            "EUR", "USD", "GBP", "CAD",
+            "AUD", "JPY", "CHF"
+    );
 
     private String stripTrailingSlash(String value) {
         if (value.endsWith("/")) {

--- a/src/test/java/finance/project/api/config/DeltaLakeConfigTest.java
+++ b/src/test/java/finance/project/api/config/DeltaLakeConfigTest.java
@@ -1,0 +1,32 @@
+package finance.project.api.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+class DeltaLakeConfigTest {
+
+    private final DeltaLakeConfig config = new DeltaLakeConfig("s3://datalake");
+
+    @Test
+    void resolvesPathWithCurrencySuffixForCryptoPairs() {
+        String path = config.resolveTablePath("CRYPTO", "ATOMUSDT");
+
+        assertThat(path).isEqualTo("s3://datalake/CRYPTO/USDT/ATOM/");
+    }
+
+    @Test
+    void resolvesPathWithSeparatorBasedCurrency() {
+        String pathUnderscore = config.resolveTablePath("ACTION", "AAPL_EUR");
+        String pathColon = config.resolveTablePath("ACTION", "AAPL:USD");
+
+        assertThat(pathUnderscore).isEqualTo("s3://datalake/ACTION/EUR/AAPL/");
+        assertThat(pathColon).isEqualTo("s3://datalake/ACTION/USD/AAPL/");
+    }
+
+    @Test
+    void sanitizesSegmentsAndFallsBackToUnknownCurrencyWhenMissing() {
+        String path = config.resolveTablePath(" Action  ", "  T TE @#  ");
+
+        assertThat(path).isEqualTo("s3://datalake/ACTION/UNKNOWN/T_TE___/");
+    }
+}


### PR DESCRIPTION
## Summary
- adjust Delta Lake table path generation to nest currency and base symbol under the asset category
- add parsing to extract currency from symbols separated by delimiters or known quote suffixes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307ebd91208323b586ae979fb5ce82)