### PR TITLE
Add IBKR contract metadata resolution and delta paths

### DIFF
--- a/src/main/java/finance/project/api/bootstrap/BootstrapData.java
+++ b/src/main/java/finance/project/api/bootstrap/BootstrapData.java
@@ -125,7 +125,9 @@ public class BootstrapData implements CommandLineRunner {
             Symbol symbol5 = createSymbol("ETHUSDT", "Ethereum", "Cryptomonnaie");
             Symbol symbol6 = createSymbol("SOLUSDT", "Solana", "Cryptomonnaie");
             Symbol symbol7 = createSymbol("APTUSDT", "Aptos", "Cryptomonnaie");
-            symbolRepository.saveAll(Arrays.asList(symbol1, symbol2, symbol3, symbol4, symbol5, symbol6, symbol7));
+            Symbol symbol8 = createSymbol("MSFT", "Microsoft", "NASDAQ");
+            Symbol symbol9 = createSymbol("TSLA", "Tesla", "NASDAQ");
+            symbolRepository.saveAll(Arrays.asList(symbol1, symbol2, symbol3, symbol4, symbol5, symbol6, symbol7, symbol8, symbol9));
         }
     }
 

--- a/src/main/java/finance/project/api/controllers/IbkrInstrumentController.java
+++ b/src/main/java/finance/project/api/controllers/IbkrInstrumentController.java
@@ -1,0 +1,29 @@
+package finance.project.api.controllers;
+
+import finance.project.api.ibkr.model.ResolvedInstrument;
+import finance.project.api.services.IbkrFxService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+
+@RestController
+public class IbkrInstrumentController {
+
+    private final IbkrFxService ibkrFxService;
+
+    public IbkrInstrumentController(IbkrFxService ibkrFxService) {
+        this.ibkrFxService = ibkrFxService;
+    }
+
+    @GetMapping("/ibkr/instruments/resolve")
+    public ResponseEntity<ResolvedInstrument> resolve(@RequestParam String symbol,
+                                                      @RequestParam(required = false) String secType,
+                                                      @RequestParam(required = false) String currency,
+                                                      @RequestParam(required = false) String exchange) {
+        ResolvedInstrument resolved = ibkrFxService.resolveContractMetadata(symbol, secType, exchange, currency, Duration.ofSeconds(5));
+        return ResponseEntity.ok(resolved);
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
+++ b/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
@@ -84,6 +84,10 @@ public class DeltaLakeExporter {
     }
 
     public void exportCandlesToDelta(DataImportJob job, List<Candle> candles) {
+        exportCandlesToDelta(job, candles, null, Collections.emptyMap());
+    }
+
+    public void exportCandlesToDelta(DataImportJob job, List<Candle> candles, String tablePath, Map<String, String> metadata) {
         if (job == null) {
             log.warn("[Delta] DataImportJob is null, skipping export");
             return;
@@ -93,31 +97,32 @@ public class DeltaLakeExporter {
             return;
         }
 
-
         String assetCategory = resolveAssetCategory(job);
-        String tablePath = deltaLakeConfig.resolveTablePath(assetCategory, job.getSymbol());
+        String effectiveTablePath = (tablePath == null || tablePath.isBlank())
+                ? deltaLakeConfig.resolveTablePath(assetCategory, job.getSymbol())
+                : stripTrailingSlash(tablePath);
         String conflictPolicy = Optional.ofNullable(job.getConflictPolicy())
                 .map(policy -> policy.toUpperCase(Locale.ROOT))
                 .orElse("MERGE");
 
         Configuration conf = createHadoopConfiguration();
         try {
-            DeltaLog deltaLog = DeltaLog.forTable(conf, tablePath);
+            DeltaLog deltaLog = DeltaLog.forTable(conf, effectiveTablePath);
 
             if ("SKIP".equals(conflictPolicy) && deltaLog.tableExists()) {
-                log.info("[Delta] Conflict policy=SKIP and table already exists at {}. Skipping export.", tablePath);
+                log.info("[Delta] Conflict policy=SKIP and table already exists at {}. Skipping export.", effectiveTablePath);
                 return;
             }
 
             OptimisticTransaction txn = deltaLog.startTransaction();
 
             if (!deltaLog.tableExists()) {
-                Metadata metadata = Metadata.builder()
+                Metadata metadataAction = Metadata.builder()
                         .schema(CANDLE_SCHEMA)
                         .name(job.getSymbol())
                         .description("Candles for " + job.getSymbol())
                         .build();
-                txn.updateMetadata(metadata);
+                txn.updateMetadata(metadataAction);
             }
 
             List<Action> actions = new ArrayList<>();
@@ -127,7 +132,7 @@ public class DeltaLakeExporter {
                         .forEach(actions::add);
             }
 
-            Path tableRoot = new Path(tablePath);
+            Path tableRoot = new Path(effectiveTablePath);
             Path dataDir = new Path(tableRoot, "data");
             Path dataFile = new Path(dataDir, "part-" + UUID.randomUUID() + ".parquet");
 
@@ -152,10 +157,13 @@ public class DeltaLakeExporter {
             Map<String, String> parameters = new HashMap<>();
             parameters.put("mode", "\"" + conflictPolicy + "\"");
             parameters.put("assetCategory", "\"" + assetCategory + "\"");
+            if (metadata != null) {
+                metadata.forEach((k, v) -> parameters.put(k, "\"" + defaultString(v) + "\""));
+            }
             Operation operation = new Operation(Operation.Name.WRITE, parameters, Collections.emptyMap());
 
             txn.commit(actions, operation, job.getId());
-            log.info("[Delta] Exported {} candles for job {} to {}", candles.size(), job.getId(), tablePath);
+            log.info("[Delta] Exported {} candles for job {} to {}", candles.size(), job.getId(), effectiveTablePath);
         } catch (Exception e) {
             log.error("[Delta] Failed to export candles for job {}: {}", job.getId(), e.getMessage(), e);
         }

--- a/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
@@ -5,11 +5,14 @@ import finance.project.api.dataimport.DataImportJob;
 import finance.project.api.dataimport.infrastructure.DeltaLakeExporter;
 import finance.project.api.entities.Candle;
 import finance.project.api.entities.Symbol;
+import finance.project.api.ibkr.IbkrRequestException;
 import finance.project.api.ibkr.model.IbkrBar;
+import finance.project.api.ibkr.model.ResolvedInstrument;
 import finance.project.api.model.market.OhlcBar;
 import finance.project.api.repositories.CandleRepository;
 import finance.project.api.repositories.SymbolRepository;
 import finance.project.api.services.IbkrFxService;
+import finance.project.api.utils.DeltaPathBuilder;
 import finance.project.api.utils.TimeframeUtils;
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -19,8 +22,10 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,15 +43,18 @@ public class IbkrImportService {
     private final CandleRepository candleRepository;
     private final SymbolRepository symbolRepository;
     private final DeltaLakeExporter deltaLakeExporter;
+    private final DeltaPathBuilder deltaPathBuilder;
 
     public IbkrImportService(IbkrFxService ibkrService,
                              CandleRepository candleRepository,
                              SymbolRepository symbolRepository,
-                             DeltaLakeExporter deltaLakeExporter) {
+                             DeltaLakeExporter deltaLakeExporter,
+                             DeltaPathBuilder deltaPathBuilder) {
         this.ibkrService = ibkrService;
         this.candleRepository = candleRepository;
         this.symbolRepository = symbolRepository;
         this.deltaLakeExporter = deltaLakeExporter;
+        this.deltaPathBuilder = deltaPathBuilder;
     }
 
     @Transactional
@@ -74,7 +82,8 @@ public class IbkrImportService {
             return;
         }
 
-        List<OhlcBar> bars = fetchIbkrHistory(symbolCode, job.getAssetClass(), start, end, job.getTimeframe());
+        FetchResult fetchResult = fetchIbkrHistory(symbolCode, job.getAssetClass(), start, end, job.getTimeframe(), symbolOpt.orElse(null));
+        List<OhlcBar> bars = fetchResult.bars();
         if (bars.isEmpty()) {
             log.info("[IBKR] No bars returned for symbol={} timeframe={}", symbolCode, job.getTimeframe());
             return;
@@ -98,7 +107,10 @@ public class IbkrImportService {
 
         candleRepository.saveAll(candles);
         log.info("[IBKR] Persisted {} candles for symbol={} timeframe={}", candles.size(), symbolCode, job.getTimeframe());
-        deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, job.getTimeframe()));
+        ResolvedInstrument resolved = fetchResult.resolvedInstrument();
+        Map<String, String> metadata = buildMetadata(resolved);
+        String deltaPath = deltaPathBuilder.buildPath(resolved);
+        deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, job.getTimeframe()), deltaPath, metadata);
     }
 
     private List<Candle> mapForDelta(List<Candle> candles, String timeframe) {
@@ -124,11 +136,31 @@ public class IbkrImportService {
         return mapped;
     }
 
-    private List<OhlcBar> fetchIbkrHistory(String symbol,
-                                           String assetClass,
-                                           Instant start,
-                                           Instant end,
-                                           String timeframe) {
+    private Map<String, String> buildMetadata(ResolvedInstrument resolved) {
+        Map<String, String> metadata = new HashMap<>();
+        if (resolved == null) {
+            metadata.put("resolveStatus", "fallback");
+            return metadata;
+        }
+        metadata.put("conid", String.valueOf(resolved.conid()));
+        metadata.put("symbol", resolved.symbol());
+        metadata.put("localSymbol", resolved.localSymbol());
+        metadata.put("tradingClass", resolved.tradingClass());
+        metadata.put("secType", resolved.secType());
+        metadata.put("currency", resolved.currency());
+        metadata.put("ibPrimaryExch", resolved.ibPrimaryExch());
+        metadata.put("normalizedExchange", resolved.normalizedExchange());
+        metadata.put("marketType", resolved.marketTypeNormalized());
+        metadata.put("resolveStatus", "resolved");
+        return metadata;
+    }
+
+    private FetchResult fetchIbkrHistory(String symbol,
+                                         String assetClass,
+                                         Instant start,
+                                         Instant end,
+                                         String timeframe,
+                                         Symbol symbolEntity) {
         String resolvedSymbol = symbol;
         String currency = "USD";
         if (symbol.contains(":")) {
@@ -137,11 +169,27 @@ public class IbkrImportService {
             currency = parts[1];
         }
         String secType = mapAssetClass(assetClass);
+
+        ResolvedInstrument resolvedInstrument = null;
+        try {
+            resolvedInstrument = ibkrService.resolveContractMetadata(resolvedSymbol,
+                    secType,
+                    symbolEntity != null ? symbolEntity.getExchange() : null,
+                    symbolEntity != null ? symbolEntity.getCurrency() : currency,
+                    Duration.ofSeconds(5));
+        } catch (IbkrRequestException ex) {
+            log.warn("[IBKR] Unable to resolve contract metadata for {}: {}. Using fallback contract.", symbol, ex.getMessage());
+        }
+
         Contract contract = new Contract();
-        contract.symbol(resolvedSymbol);
-        contract.secType(secType);
-        contract.currency(currency);
+        contract.symbol(resolvedInstrument != null ? resolvedInstrument.symbol() : resolvedSymbol);
+        contract.secType(resolvedInstrument != null ? resolvedInstrument.secType() : secType);
+        contract.currency(resolvedInstrument != null ? resolvedInstrument.currency() : currency);
         contract.exchange("SMART");
+        if (resolvedInstrument != null) {
+            contract.conid(resolvedInstrument.conid());
+            contract.primaryExch(resolvedInstrument.ibPrimaryExch());
+        }
 
         String barSize = toIbBarSize(timeframe);
         Duration diff = Duration.between(start, end);
@@ -162,8 +210,10 @@ public class IbkrImportService {
             }
             result.add(new OhlcBar(bar.time(), bar.open(), bar.high(), bar.low(), bar.close(), bar.volume()));
         }
-        return result;
+        return new FetchResult(result, resolvedInstrument);
     }
+
+    private record FetchResult(List<OhlcBar> bars, ResolvedInstrument resolvedInstrument) {}
 
     private String mapAssetClass(String assetClass) {
         if (assetClass == null || assetClass.isBlank()) {

--- a/src/main/java/finance/project/api/ibkr/model/ResolvedInstrument.java
+++ b/src/main/java/finance/project/api/ibkr/model/ResolvedInstrument.java
@@ -1,0 +1,17 @@
+package finance.project.api.ibkr.model;
+
+/**
+ * Metadata resolved from IBKR contract details.
+ */
+public record ResolvedInstrument(
+        int conid,
+        String symbol,
+        String localSymbol,
+        String tradingClass,
+        String secType,
+        String currency,
+        String ibPrimaryExch,
+        String normalizedExchange,
+        String marketTypeNormalized
+) {
+}

--- a/src/main/java/finance/project/api/services/IbkrFxService.java
+++ b/src/main/java/finance/project/api/services/IbkrFxService.java
@@ -7,6 +7,7 @@ import finance.project.api.config.IbkrProperties;
 import finance.project.api.ibkr.IbkrRequestException;
 import finance.project.api.ibkr.model.IbkrBar;
 import finance.project.api.ibkr.model.IbkrScannerRow;
+import finance.project.api.ibkr.model.ResolvedInstrument;
 import finance.project.api.model.fx.FxQuote;
 import finance.project.api.model.fx.HistBar;
 import org.slf4j.Logger;
@@ -63,6 +64,7 @@ public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataSer
     private final ConcurrentHashMap<Integer, List<IbkrScannerRow>> scannerBuffers = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, CompletableFuture<List<IbkrBar>>> genericHistFutures = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, List<IbkrBar>> genericHistBuffers = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, CompletableFuture<ContractDetails>> contractDetailsFutures = new ConcurrentHashMap<>();
 
     private volatile List<String> managedAccts = List.of();
 
@@ -87,6 +89,21 @@ public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataSer
             "1 min","2 mins","3 mins","5 mins","10 mins","15 mins","20 mins","30 mins",
             "1 hour","2 hours","3 hours","4 hours","8 hours",
             "1 day","1W","1M"
+    );
+
+    private static final Map<String, String> EXCHANGE_NORMALIZATION = Map.ofEntries(
+            Map.entry("NASDAQ", "NASDAQ"),
+            Map.entry("NYSE", "NYSE"),
+            Map.entry("ARCA", "ARCA"),
+            Map.entry("IBIS", "XETRA"),
+            Map.entry("IBIS2", "XETRA"),
+            Map.entry("BVME", "BORSA_ITALIANA"),
+            Map.entry("SBF", "EURONEXT_PARIS"),
+            Map.entry("AEB", "EURONEXT_AMSTERDAM"),
+            Map.entry("LSE", "LSE"),
+            Map.entry("EBS", "IDEALPRO"),
+            Map.entry("IDEALPRO", "IDEALPRO"),
+            Map.entry("SMART", "SMART")
     );
 
     // --- Account Summary snapshot ---
@@ -336,6 +353,52 @@ public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataSer
         }
     }
 
+    public ResolvedInstrument resolveContractMetadata(String symbol,
+                                                      String secTypeHint,
+                                                      String exchangeHint,
+                                                      String currencyHint,
+                                                      Duration timeout) {
+        Objects.requireNonNull(symbol, "symbol");
+        if (!ensureConnected()) {
+            throw new IbkrRequestException("Unable to connect to IBKR gateway");
+        }
+        waitForPacingSlot();
+
+        int id = reqId.getAndIncrement();
+        CompletableFuture<ContractDetails> future = new CompletableFuture<>();
+        contractDetailsFutures.put(id, future);
+
+        Contract probe = new Contract();
+        probe.symbol(symbol);
+        probe.secType(defaultSecType(secTypeHint));
+        probe.exchange("SMART");
+        if (currencyHint != null && !currencyHint.isBlank()) {
+            probe.currency(currencyHint);
+        }
+        if (exchangeHint != null && !exchangeHint.isBlank()) {
+            probe.primaryExch(exchangeHint);
+        }
+
+        client.reqContractDetails(id, probe);
+
+        try {
+            long timeoutMillis = timeout != null ? timeout.toMillis() : 5000L;
+            ContractDetails details = future.get(timeoutMillis, TimeUnit.MILLISECONDS);
+            ResolvedInstrument resolved = toResolvedInstrument(details, secTypeHint, exchangeHint, currencyHint);
+            log.info("Resolved {} -> conid={} secType={} currency={} primaryExch={} (normalized={}) marketType={} pathSegment={}/{}", symbol,
+                    resolved.conid(), resolved.secType(), resolved.currency(), resolved.ibPrimaryExch(),
+                    resolved.normalizedExchange(), resolved.marketTypeNormalized(), resolved.normalizedExchange(), resolved.symbol());
+            return resolved;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IbkrRequestException("Interrupted while waiting for contract details", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IbkrRequestException("Unable to resolve contract details for %s".formatted(symbol), e);
+        } finally {
+            contractDetailsFutures.remove(id);
+        }
+    }
+
     /** ----------- LIVE FX EURUSD ----------- */
 
     /** Démarre un flux de bougies 1 minute (EURUSD MIDPOINT) en "keepUpToDate". */
@@ -555,6 +618,22 @@ public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataSer
     }
 
     @Override
+    public void contractDetails(int reqId, ContractDetails contractDetails) {
+        CompletableFuture<ContractDetails> future = contractDetailsFutures.get(reqId);
+        if (future != null && !future.isDone()) {
+            future.complete(contractDetails);
+        }
+    }
+
+    @Override
+    public void contractDetailsEnd(int reqId) {
+        CompletableFuture<ContractDetails> future = contractDetailsFutures.remove(reqId);
+        if (future != null && !future.isDone()) {
+            future.completeExceptionally(new IbkrRequestException("No contract details returned for reqId " + reqId));
+        }
+    }
+
+    @Override
     public void scannerData(int reqId, int rank, ContractDetails contractDetails, String distance, String benchmark, String projection, String legsStr) {
         List<IbkrScannerRow> buffer = scannerBuffers.get(reqId);
         if (buffer != null) {
@@ -623,6 +702,77 @@ public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataSer
         }
     }
 
+    private ResolvedInstrument toResolvedInstrument(ContractDetails details,
+                                                    String secTypeHint,
+                                                    String exchangeHint,
+                                                    String currencyHint) {
+        Contract c = details.contract();
+        String secType = safeUpper(firstNonBlank(c.secType(), secTypeHint, Types.SecType.STK.name()));
+        String currency = firstNonBlank(c.currency(), currencyHint, "USD");
+        String ibPrimary = firstNonBlank(c.primaryExch(), exchangeHint, c.exchange());
+        String normalizedExchange = normalizeExchange(ibPrimary);
+        String marketType = normalizeMarketType(secType, details);
+        return new ResolvedInstrument(
+                c.conid(),
+                c.symbol(),
+                c.localSymbol(),
+                c.tradingClass(),
+                secType,
+                currency,
+                ibPrimary,
+                normalizedExchange,
+                marketType
+        );
+    }
+
+    private String normalizeMarketType(String secType, ContractDetails details) {
+        return switch (safeUpper(secType)) {
+            case "STK" -> isEtf(details) ? "ETF" : "STOCK";
+            case "CASH" -> "FOREX";
+            case "FUT" -> "FUTURE";
+            case "IND" -> "INDEX";
+            case "CRYPTO" -> "CRYPTO";
+            default -> safeUpper(secType);
+        };
+    }
+
+    private boolean isEtf(ContractDetails details) {
+        String stockType = safeUpper(details.stockType());
+        if (stockType.contains("ETF")) {
+            return true;
+        }
+        String name = safeUpper(details.longName());
+        return name.contains("ETF");
+    }
+
+    private String normalizeExchange(String exchange) {
+        String upper = safeUpper(exchange);
+        if (upper.isEmpty()) {
+            return "UNKNOWN";
+        }
+        return EXCHANGE_NORMALIZATION.getOrDefault(upper, upper.replace(' ', '_'));
+    }
+
+    private String defaultSecType(String secTypeHint) {
+        if (secTypeHint == null || secTypeHint.isBlank()) {
+            return Types.SecType.STK.name();
+        }
+        return secTypeHint.toUpperCase(Locale.ROOT);
+    }
+
+    private String safeUpper(String value) {
+        return value == null ? "" : value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String v : values) {
+            if (v != null && !v.isBlank()) {
+                return v;
+            }
+        }
+        return "";
+    }
+
     /** Conversion IB time → epoch millis (IB renvoie "yyyyMMdd  HH:mm:ss" ou epoch) */
     private long parseIbDateTime(String ibTime) {
         if (ibTime == null || ibTime.isEmpty()) throw new IllegalArgumentException("empty ibTime");
@@ -683,6 +833,10 @@ public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataSer
         CompletableFuture<List<IbkrBar>> histFuture = genericHistFutures.get(reqId);
         if (histFuture != null && !histFuture.isDone()) {
             histFuture.completeExceptionally(new IbkrRequestException("Historical error %d: %s".formatted(errorCode, errorMsg)));
+        }
+        CompletableFuture<ContractDetails> contractFuture = contractDetailsFutures.get(reqId);
+        if (contractFuture != null && !contractFuture.isDone()) {
+            contractFuture.completeExceptionally(new IbkrRequestException("Contract details error %d: %s".formatted(errorCode, errorMsg)));
         }
         if (errorCode == 420 || errorCode == 421) {
             log.warn("IBKR pacing violation reported: {}", errorMsg);

--- a/src/main/java/finance/project/api/services/IbkrFxService.java
+++ b/src/main/java/finance/project/api/services/IbkrFxService.java
@@ -707,7 +707,7 @@ public class IbkrFxService extends IbkrWrapperAdapter implements FxMarketDataSer
                                                     String exchangeHint,
                                                     String currencyHint) {
         Contract c = details.contract();
-        String secType = safeUpper(firstNonBlank(c.secType(), secTypeHint, Types.SecType.STK.name()));
+        String secType = safeUpper(firstNonBlank(String.valueOf(c.secType()), secTypeHint, Types.SecType.STK.name()));
         String currency = firstNonBlank(c.currency(), currencyHint, "USD");
         String ibPrimary = firstNonBlank(c.primaryExch(), exchangeHint, c.exchange());
         String normalizedExchange = normalizeExchange(ibPrimary);

--- a/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
+++ b/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
@@ -1,0 +1,42 @@
+package finance.project.api.utils;
+
+import finance.project.api.config.DeltaLakeConfig;
+import finance.project.api.ibkr.model.ResolvedInstrument;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Locale;
+
+@Component
+public class DeltaPathBuilder {
+
+    private final DeltaLakeConfig deltaLakeConfig;
+
+    public DeltaPathBuilder(DeltaLakeConfig deltaLakeConfig) {
+        this.deltaLakeConfig = deltaLakeConfig;
+    }
+
+    public String buildPath(ResolvedInstrument instrument) {
+        String market = sanitize(instrument != null ? instrument.marketTypeNormalized() : "UNKNOWN");
+        String exchange = sanitize(instrument != null ? instrument.normalizedExchange() : "UNKNOWN");
+        String currency = sanitize(instrument != null ? instrument.currency() : "UNKNOWN");
+        String symbol = sanitize(instrument != null ? instrument.symbol() : "UNKNOWN");
+        return "%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, exchange, currency, symbol);
+    }
+
+    private String sanitize(String value) {
+        if (value == null) {
+            return "UNKNOWN";
+        }
+        String cleaned = StringUtils.trimWhitespace(value)
+                .replace('\\', '_')
+                .replace('/', '_')
+                .replaceAll("\\s+", "_")
+                .toUpperCase(Locale.ROOT);
+        cleaned = cleaned.replaceAll("[^A-Z0-9._-]", "_");
+        if (cleaned.isBlank()) {
+            return "UNKNOWN";
+        }
+        return cleaned;
+    }
+}


### PR DESCRIPTION
## Summary
- resolve IBKR contracts via `reqContractDetails` to capture conid, exchange, currency, and market type metadata with normalized values
- reuse resolved metadata when requesting historical data, building Delta Lake paths, and exporting metadata alongside candle writes
- add a debug endpoint and Delta path utility to inspect instrument resolution results

## Testing
- `mvn -DskipTests compile -q` *(fails: missing dependency com.ib:tws-api-proto:10.40 on Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940114ad5a0832386ab15426cce9c51)