### PR TITLE
Expose intermediate_entries and add delta-lake fallback for /from-trade

### DIFF
--- a/src/main/java/finance/project/api/controllers/BacktestController.java
+++ b/src/main/java/finance/project/api/controllers/BacktestController.java
@@ -3,7 +3,6 @@ package finance.project.api.controllers;
 import finance.project.api.entities.MarketData;
 import finance.project.api.entities.Performance;
 import finance.project.api.entities.Trade;
-import finance.project.api.entities.TradeCompleted;
 import finance.project.api.model.*;
 import finance.project.api.services.*;
 import finance.project.api.strategies.StrategyManager;
@@ -39,12 +38,13 @@ public class BacktestController {
     private final PerformanceService performanceService;
     private final TradeService tradeService;
     private final TradeCompletedService tradeCompletedService;
+    private final TradeCompletedMapper tradeCompletedMapper;
 
     @Autowired
     private CandleCacheManager candleCacheManager;
 
     @Autowired
-    public BacktestController(TA4JService ta4JService, VolumeBasedRolloverService volumeBasedRolloverService, EmaVolumeStrategy emaVolumeStrategy, SymbolService symbolService, CandleService candleService, StrategyManager strategyManager, MarketDataService marketDataService, PerformanceService performanceService, TradeService tradeService, TradeCompletedService tradeCompletedService) {
+    public BacktestController(TA4JService ta4JService, VolumeBasedRolloverService volumeBasedRolloverService, EmaVolumeStrategy emaVolumeStrategy, SymbolService symbolService, CandleService candleService, StrategyManager strategyManager, MarketDataService marketDataService, PerformanceService performanceService, TradeService tradeService, TradeCompletedService tradeCompletedService, TradeCompletedMapper tradeCompletedMapper) {
         this.ta4JService = ta4JService;
         this.volumeBasedRolloverService = volumeBasedRolloverService;
         this.emaVolumeStrategy = emaVolumeStrategy;
@@ -54,6 +54,7 @@ public class BacktestController {
         this.performanceService = performanceService;
         this.tradeService = tradeService;
         this.tradeCompletedService = tradeCompletedService;
+        this.tradeCompletedMapper = tradeCompletedMapper;
     }
     @GetMapping("/run-strategy")
     public ResponseEntity<String> runStrategy(@RequestParam String symbol,
@@ -164,8 +165,10 @@ public class BacktestController {
     }
 
     @GetMapping("/get-trades-strategy")
-    public ResponseEntity<List<TradeCompleted>> getTradesByStrategy(@RequestParam String strategyName, @RequestParam String runId) {
-        List<TradeCompleted> trades = tradeCompletedService.getTradesByStrategyAndRunId(strategyName, runId);
+    public ResponseEntity<List<TradeCompletedDTO>> getTradesByStrategy(@RequestParam String strategyName, @RequestParam String runId) {
+        List<TradeCompletedDTO> trades = tradeCompletedService.getTradesByStrategyAndRunId(strategyName, runId).stream()
+                .map(tradeCompletedMapper::toDto)
+                .toList();
         if (trades.isEmpty()) {
             return ResponseEntity.noContent().build();
         }

--- a/src/main/java/finance/project/api/controllers/CandleController.java
+++ b/src/main/java/finance/project/api/controllers/CandleController.java
@@ -9,6 +9,7 @@ import finance.project.api.enums.MarketType;
 import finance.project.api.model.CandleDTO;
 import finance.project.api.model.CandleFilterDTO;
 import finance.project.api.model.SymbolDTO;
+import finance.project.api.model.TradeCompletedDTO;
 import finance.project.api.services.*;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -59,6 +60,9 @@ public class CandleController {
     private final VolumeBasedRolloverService volumeBasedRolloverService;
 
     private final TradeCompletedService tradeCompletedService;
+    private final TradeCompletedMapper tradeCompletedMapper;
+    private final DeltaLakeCandleReader deltaLakeCandleReader;
+    private final TradeCompletedMapper tradeCompletedMapper;
 
     private final BinanceService binanceService;
 
@@ -282,15 +286,20 @@ public class CandleController {
 
         TradeCompleted trade = tradeCompletedService.getTradeById(tradeId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Trade not found"));
+        TradeCompletedDTO tradeDto = tradeCompletedMapper.toDto(trade);
+        String tradeSymbol = trade.getSymbol();
 
         // A ajouter trade.getSymbol() au lieu de EURUSD en dur
-        List<CandleDTO> candles = candleService.getCandlesForTrade(trade, symbol, timeframe, beforeCandles, afterCandles);
+        List<CandleDTO> candles = candleService.getCandlesForTrade(trade, tradeSymbol, timeframe, beforeCandles, afterCandles);
+        if (candles.isEmpty()) {
+            candles = deltaLakeCandleReader.getCandlesForTrade(trade, timeframe, beforeCandles, afterCandles);
+        }
         List<CandleDTO> candlesComparedSymbol = candleService.getCandlesForTrade(trade, comparedSymbol, timeframe, beforeCandles, afterCandles);
 
         Map<String, Object> response = new HashMap<>();
         response.put("candles", candles);
         response.put("comparedCandles", candlesComparedSymbol);
-        response.put("trade", trade);
+        response.put("trade", tradeDto);
 
         return response;
     }

--- a/src/main/java/finance/project/api/controllers/CandleController.java
+++ b/src/main/java/finance/project/api/controllers/CandleController.java
@@ -62,7 +62,6 @@ public class CandleController {
     private final TradeCompletedService tradeCompletedService;
     private final TradeCompletedMapper tradeCompletedMapper;
     private final DeltaLakeCandleReader deltaLakeCandleReader;
-    private final TradeCompletedMapper tradeCompletedMapper;
 
     private final BinanceService binanceService;
 

--- a/src/main/java/finance/project/api/model/IntermediateEntryDTO.java
+++ b/src/main/java/finance/project/api/model/IntermediateEntryDTO.java
@@ -1,0 +1,18 @@
+package finance.project.api.model;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.time.OffsetDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record IntermediateEntryDTO(
+        int index,
+        @JsonAlias("ts_utc") OffsetDateTime tsUtc,
+        double qty,
+        double price,
+        @JsonAlias("grid_level") Double gridLevel,
+        @JsonAlias("dd_pct") Double ddPct,
+        @JsonAlias("palier_used") Double palierUsed
+) {
+}

--- a/src/main/java/finance/project/api/model/TradeCompletedDTO.java
+++ b/src/main/java/finance/project/api/model/TradeCompletedDTO.java
@@ -1,0 +1,28 @@
+package finance.project.api.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TradeCompletedDTO(
+        Long id,
+        String strategyName,
+        String runId,
+        TradeSignalDTO.TradeType tradeType,
+        String assetClass,
+        double entryPrice,
+        double stopLoss,
+        double takeProfit,
+        double exitPrice,
+        double profitOrLoss,
+        BigDecimal pnlPct,
+        BigDecimal maxDrawdownPct,
+        BigDecimal quantity,
+        Integer cycleId,
+        double confidenceScore,
+        LocalDateTime entryTimestamp,
+        LocalDateTime exitTimestamp,
+        String symbol,
+        List<IntermediateEntryDTO> intermediateEntries
+) {
+}

--- a/src/main/java/finance/project/api/services/DeltaLakeCandleReader.java
+++ b/src/main/java/finance/project/api/services/DeltaLakeCandleReader.java
@@ -1,0 +1,179 @@
+package finance.project.api.services;
+
+import finance.project.api.config.DeltaLakeConfig;
+import finance.project.api.entities.TradeCompleted;
+import finance.project.api.model.CandleDTO;
+import finance.project.api.model.SymbolDTO;
+import finance.project.api.utils.DurationUtils;
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.actions.AddFile;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Service
+public class DeltaLakeCandleReader {
+
+    private static final Logger log = LoggerFactory.getLogger(DeltaLakeCandleReader.class);
+
+    private final DeltaLakeConfig deltaLakeConfig;
+
+    public DeltaLakeCandleReader(DeltaLakeConfig deltaLakeConfig) {
+        this.deltaLakeConfig = deltaLakeConfig;
+    }
+
+    public List<CandleDTO> getCandlesForTrade(TradeCompleted trade, String timeframe, int beforeCandles, int afterCandles) {
+        if (trade == null) {
+            return List.of();
+        }
+        Duration tfDuration = DurationUtils.parseTimeframe(timeframe);
+        LocalDateTime start = trade.getEntryTimestamp().minus(tfDuration.multipliedBy(beforeCandles));
+        LocalDateTime end = trade.getExitTimestamp().plus(tfDuration.multipliedBy(afterCandles));
+        String tablePath = buildDeltaPath(trade);
+        return loadCandles(tablePath, trade.getSymbol(), timeframe, start, end);
+    }
+
+    private List<CandleDTO> loadCandles(String tablePath, String symbol, String timeframe, LocalDateTime start, LocalDateTime end) {
+        if (tablePath == null || tablePath.isBlank()) {
+            return List.of();
+        }
+        Configuration conf = createHadoopConfiguration();
+        DeltaLog deltaLog = DeltaLog.forTable(conf, stripTrailingSlash(tablePath));
+        if (!deltaLog.tableExists()) {
+            log.warn("[Delta] Table not found at {}", tablePath);
+            return List.of();
+        }
+
+        List<CandleDTO> candles = new ArrayList<>();
+        Path tableRoot = new Path(stripTrailingSlash(tablePath));
+        for (AddFile addFile : deltaLog.snapshot().getAllFiles()) {
+            Path filePath = resolveFilePath(tableRoot, addFile.getPath());
+            candles.addAll(readParquet(filePath, conf, symbol, timeframe, start, end));
+        }
+        return candles;
+    }
+
+    private List<CandleDTO> readParquet(Path filePath,
+                                        Configuration conf,
+                                        String symbol,
+                                        String timeframe,
+                                        LocalDateTime start,
+                                        LocalDateTime end) {
+        List<CandleDTO> results = new ArrayList<>();
+        try (ParquetReader<GenericRecord> reader = AvroParquetReader.<GenericRecord>builder(filePath)
+                .withConf(conf)
+                .build()) {
+            GenericRecord record;
+            while ((record = reader.read()) != null) {
+                String recordTimeframe = Optional.ofNullable(record.get("timeframe"))
+                        .map(Object::toString)
+                        .orElse("");
+                if (!recordTimeframe.equalsIgnoreCase(timeframe)) {
+                    continue;
+                }
+                Long timestamp = (Long) record.get("timestamp");
+                if (timestamp == null) {
+                    continue;
+                }
+                LocalDateTime date = Instant.ofEpochMilli(timestamp).atOffset(ZoneOffset.UTC).toLocalDateTime();
+                if (date.isBefore(start) || date.isAfter(end)) {
+                    continue;
+                }
+
+                results.add(CandleDTO.builder()
+                        .timeframe(recordTimeframe)
+                        .date(date)
+                        .open(asBigDecimal(record.get("open")))
+                        .close(asBigDecimal(record.get("close")))
+                        .high(asBigDecimal(record.get("high")))
+                        .low(asBigDecimal(record.get("low")))
+                        .volume(asBigDecimal(record.get("volume")))
+                        .symbol(SymbolDTO.builder().symbol(symbol).build())
+                        .build());
+            }
+        } catch (IOException e) {
+            log.warn("[Delta] Failed to read parquet {}: {}", filePath, e.getMessage());
+        }
+        return results;
+    }
+
+    private String buildDeltaPath(TradeCompleted trade) {
+        String market = resolveMarket(trade.getAssetClass());
+        String exchange = "NASDAQ";
+        String currency = "USD";
+        String symbol = Optional.ofNullable(trade.getSymbol()).orElse("UNKNOWN");
+        return "%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, exchange, currency, symbol);
+    }
+
+    private String resolveMarket(String assetClass) {
+        String normalized = Optional.ofNullable(assetClass).orElse("").toUpperCase(Locale.ROOT);
+        if (normalized.contains("EQUITY")) {
+            return "STOCK";
+        }
+        return normalized.isBlank() ? "UNKNOWN" : normalized;
+    }
+
+    private BigDecimal asBigDecimal(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Double doubleValue) {
+            return BigDecimal.valueOf(doubleValue);
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        return null;
+    }
+
+    private Path resolveFilePath(Path tableRoot, String addFilePath) {
+        if (addFilePath == null) {
+            return tableRoot;
+        }
+        if (addFilePath.contains("://")) {
+            return new Path(addFilePath);
+        }
+        return new Path(tableRoot, addFilePath);
+    }
+
+    private String stripTrailingSlash(String value) {
+        if (value.endsWith("/")) {
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private Configuration createHadoopConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        configuration.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        configuration.set("fs.s3a.endpoint", "http://localhost:9000");
+        configuration.setBoolean("fs.s3a.path.style.access", true);
+        configuration.setBoolean("fs.s3a.connection.ssl.enabled", false);
+        configuration.set("fs.s3a.access.key", "minioadmin");
+        configuration.set("fs.s3a.secret.key", "minioadmin");
+        configuration.set("fs.s3a.fast.upload", "true");
+        configuration.set("fs.s3a.fast.upload.buffer", "array");
+        configuration.set("fs.s3a.block.size", "8m");
+        configuration.set("fs.s3a.multipart.size", "8m");
+        configuration.set("fs.s3a.multipart.threshold", "8m");
+        configuration.set("hadoop.tmp.dir", "C:/hadoop-tmp");
+        return configuration;
+    }
+}

--- a/src/main/java/finance/project/api/services/TradeCompletedMapper.java
+++ b/src/main/java/finance/project/api/services/TradeCompletedMapper.java
@@ -1,0 +1,59 @@
+package finance.project.api.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import finance.project.api.entities.TradeCompleted;
+import finance.project.api.model.IntermediateEntryDTO;
+import finance.project.api.model.TradeCompletedDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TradeCompletedMapper {
+
+    private final ObjectMapper objectMapper;
+
+    public TradeCompletedDTO toDto(TradeCompleted trade) {
+        return new TradeCompletedDTO(
+                trade.getId(),
+                trade.getStrategyName(),
+                trade.getRunId(),
+                trade.getTradeType(),
+                trade.getAssetClass(),
+                trade.getEntryPrice(),
+                trade.getStopLoss(),
+                trade.getTakeProfit(),
+                trade.getExitPrice(),
+                trade.getProfitOrLoss(),
+                trade.getPnlPct(),
+                trade.getMaxDrawdownPct(),
+                trade.getQuantity(),
+                trade.getCycleId(),
+                trade.getConfidenceScore(),
+                trade.getEntryTimestamp(),
+                trade.getExitTimestamp(),
+                trade.getSymbol(),
+                extractIntermediateEntries(trade.getMetaJson())
+        );
+    }
+
+    private List<IntermediateEntryDTO> extractIntermediateEntries(String metaJson) {
+        if (metaJson == null || metaJson.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(metaJson);
+            JsonNode entriesNode = root.get("intermediate_entries");
+            if (entriesNode == null || !entriesNode.isArray() || entriesNode.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return objectMapper.readerForListOf(IntermediateEntryDTO.class).readValue(entriesNode);
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/test/java/finance/project/api/services/TradeCompletedMapperTest.java
+++ b/src/test/java/finance/project/api/services/TradeCompletedMapperTest.java
@@ -1,0 +1,64 @@
+package finance.project.api.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import finance.project.api.entities.TradeCompleted;
+import finance.project.api.model.TradeCompletedDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TradeCompletedMapperTest {
+
+    private TradeCompletedMapper tradeCompletedMapper;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        tradeCompletedMapper = new TradeCompletedMapper(objectMapper);
+    }
+
+    @Test
+    void toDtoWithoutIntermediateEntriesReturnsEmptyList() {
+        TradeCompleted trade = TradeCompleted.builder()
+                .metaJson("{\"foo\":\"bar\"}")
+                .build();
+
+        TradeCompletedDTO dto = tradeCompletedMapper.toDto(trade);
+
+        assertThat(dto.intermediateEntries()).isEmpty();
+    }
+
+    @Test
+    void toDtoWithEmptyIntermediateEntriesReturnsEmptyList() {
+        TradeCompleted trade = TradeCompleted.builder()
+                .metaJson("{\"intermediate_entries\":[]}")
+                .build();
+
+        TradeCompletedDTO dto = tradeCompletedMapper.toDto(trade);
+
+        assertThat(dto.intermediateEntries()).isEmpty();
+    }
+
+    @Test
+    void toDtoWithIntermediateEntriesMapsFields() {
+        TradeCompleted trade = TradeCompleted.builder()
+                .metaJson("{\"intermediate_entries\":[{\"index\":1,\"ts_utc\":\"2025-04-08T00:00:00+00:00\",\"qty\":0.2,\"price\":172.42,\"grid_level\":-30.0,\"dd_pct\":-30.2225,\"palier_used\":0.2}]}")
+                .build();
+
+        TradeCompletedDTO dto = tradeCompletedMapper.toDto(trade);
+
+        assertThat(dto.intermediateEntries()).hasSize(1);
+        var entry = dto.intermediateEntries().getFirst();
+        assertThat(entry.index()).isEqualTo(1);
+        assertThat(entry.tsUtc()).isEqualTo(OffsetDateTime.parse("2025-04-08T00:00:00+00:00"));
+        assertThat(entry.qty()).isEqualTo(0.2);
+        assertThat(entry.price()).isEqualTo(172.42);
+        assertThat(entry.gridLevel()).isEqualTo(-30.0);
+        assertThat(entry.ddPct()).isEqualTo(-30.2225);
+        assertThat(entry.palierUsed()).isEqualTo(0.2);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a typed API field for `intermediate_entries` parsed from `TradeCompleted.metaJson` so the frontend doesn't need to parse JSON.
- Ensure `/from-trade` uses the trade's actual symbol (multi-asset strategies) instead of the request parameter and fall back to Delta Lake when DB candles are missing.
- Keep business logic unchanged and add a presentation/reading layer with safe defaults for missing data.

### Description
- Add `IntermediateEntryDTO` record (with `OffsetDateTime tsUtc` and `@JsonAlias` for snake_case fields) and include a `List<IntermediateEntryDTO> intermediateEntries` in the new `TradeCompletedDTO` record.
- Implement `TradeCompletedMapper` that uses Jackson `ObjectMapper` to parse `metaJson`, extract `intermediate_entries` and return `Collections.emptyList()` when absent, empty or on parse errors.
- Wire mapper into controllers: `BacktestController#getTradesByStrategy` now returns `List<TradeCompletedDTO>` and `CandleController#/from-trade` returns the mapped `trade` DTO and uses the trade's symbol when requesting candles.
- Add `DeltaLakeCandleReader` service to build a Delta path from `assetClass`/symbol (defaults: exchange=`NASDAQ`, currency=`USD`, and treat asset class containing `EQUITY` as `STOCK`) and read parquet files via `DeltaLog`/Parquet reader as a fallback when DB candles are not found.

### Testing
- Added unit tests `TradeCompletedMapperTest` covering: missing `intermediate_entries`, empty array, and populated entry mapping with timestamp parsing and nullable fields.
- No automated test suite was executed in this rollout (tests added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694711cd52d48323a1091f34553391da)