### PR TITLE
Add broker and venue segments to Delta Lake paths

### DIFF
--- a/src/main/java/finance/project/api/config/DeltaLakeConfig.java
+++ b/src/main/java/finance/project/api/config/DeltaLakeConfig.java
@@ -24,14 +24,17 @@ public class DeltaLakeConfig {
         return baseUri;
     }
 
-    public String resolveTablePath(String assetCategory, String symbol) {
+    public String resolveTablePath(String assetCategory, String broker, String venue, String symbol) {
         Assert.hasText(assetCategory, "assetCategory must not be blank");
         Assert.hasText(symbol, "symbol must not be blank");
 
         String sanitizedCategory = sanitizeSegment(assetCategory);
+        String sanitizedBroker = sanitizeSegment(broker);
+        String sanitizedVenue = sanitizeSegment(venue);
         SymbolPathSegments segments = parseSymbolSegments(symbol);
 
-        return baseUri + "/" + sanitizedCategory + "/" + segments.currency() + "/" + segments.baseSymbol() + "/";
+        return baseUri + "/" + sanitizedCategory + "/" + sanitizedBroker + "/" + sanitizedVenue + "/"
+                + segments.currency() + "/" + segments.baseSymbol() + "/";
     }
 
     private SymbolPathSegments parseSymbolSegments(String symbol) {
@@ -59,6 +62,9 @@ public class DeltaLakeConfig {
     }
 
     private String sanitizeSegment(String value) {
+        if (value == null) {
+            return "UNKNOWN";
+        }
         String sanitized = StringUtils.trimAllWhitespace(value).replaceAll("[^a-zA-Z0-9_-]", "_");
         return sanitized.isEmpty() ? "UNKNOWN" : sanitized.toUpperCase();
     }

--- a/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
+++ b/src/main/java/finance/project/api/dataimport/infrastructure/DeltaLakeExporter.java
@@ -99,7 +99,7 @@ public class DeltaLakeExporter {
 
         String assetCategory = resolveAssetCategory(job);
         String effectiveTablePath = (tablePath == null || tablePath.isBlank())
-                ? deltaLakeConfig.resolveTablePath(assetCategory, job.getSymbol())
+                ? deltaLakeConfig.resolveTablePath(assetCategory, job.getBroker(), job.getVenue(), job.getSymbol())
                 : stripTrailingSlash(tablePath);
         String conflictPolicy = Optional.ofNullable(job.getConflictPolicy())
                 .map(policy -> policy.toUpperCase(Locale.ROOT))

--- a/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/IbkrImportService.java
@@ -115,7 +115,7 @@ public class IbkrImportService {
             log.info("[IBKR] Persisted {} candles for symbol={} timeframe={}", candles.size(), symbolCode, job.getTimeframe());
             ResolvedInstrument resolved = fetchResult.resolvedInstrument();
             Map<String, String> metadata = buildMetadata(resolved);
-            String deltaPath = deltaPathBuilder.buildPath(resolved);
+            String deltaPath = deltaPathBuilder.buildPath(resolved, job.getBroker());
             log.info("[IBKR][DELTA][{}] exporting {} candles to path={} metadata={}",
                     runId, candles.size(), deltaPath, metadata);
             deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, job.getTimeframe()), deltaPath, metadata);

--- a/src/main/java/finance/project/api/services/DeltaLakeCandleReader.java
+++ b/src/main/java/finance/project/api/services/DeltaLakeCandleReader.java
@@ -115,10 +115,11 @@ public class DeltaLakeCandleReader {
 
     private String buildDeltaPath(TradeCompleted trade) {
         String market = resolveMarket(trade.getAssetClass());
+        String broker = "UNKNOWN";
         String exchange = "NASDAQ";
         String currency = "USD";
         String symbol = Optional.ofNullable(trade.getSymbol()).orElse("UNKNOWN");
-        return "%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, exchange, currency, symbol);
+        return "%s/%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, broker, exchange, currency, symbol);
     }
 
     private String resolveMarket(String assetClass) {

--- a/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
+++ b/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
@@ -16,12 +16,13 @@ public class DeltaPathBuilder {
         this.deltaLakeConfig = deltaLakeConfig;
     }
 
-    public String buildPath(ResolvedInstrument instrument) {
+    public String buildPath(ResolvedInstrument instrument, String broker) {
         String market = sanitize(instrument != null ? instrument.marketTypeNormalized() : "UNKNOWN");
+        String brokerSegment = sanitize(broker);
         String exchange = sanitize(instrument != null ? instrument.normalizedExchange() : "UNKNOWN");
         String currency = sanitize(instrument != null ? instrument.currency() : "UNKNOWN");
         String symbol = sanitize(instrument != null ? instrument.symbol() : "UNKNOWN");
-        return "%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, exchange, currency, symbol);
+        return "%s/%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, brokerSegment, exchange, currency, symbol);
     }
 
     private String sanitize(String value) {

--- a/src/test/java/finance/project/api/config/DeltaLakeConfigTest.java
+++ b/src/test/java/finance/project/api/config/DeltaLakeConfigTest.java
@@ -9,24 +9,24 @@ class DeltaLakeConfigTest {
 
     @Test
     void resolvesPathWithCurrencySuffixForCryptoPairs() {
-        String path = config.resolveTablePath("CRYPTO", "ATOMUSDT");
+        String path = config.resolveTablePath("CRYPTO", "BINANCE", "SPOT", "ATOMUSDT");
 
-        assertThat(path).isEqualTo("s3://datalake/CRYPTO/USDT/ATOM/");
+        assertThat(path).isEqualTo("s3://datalake/CRYPTO/BINANCE/SPOT/USDT/ATOM/");
     }
 
     @Test
     void resolvesPathWithSeparatorBasedCurrency() {
-        String pathUnderscore = config.resolveTablePath("ACTION", "AAPL_EUR");
-        String pathColon = config.resolveTablePath("ACTION", "AAPL:USD");
+        String pathUnderscore = config.resolveTablePath("ACTION", "IBKR", "NYSE", "AAPL_EUR");
+        String pathColon = config.resolveTablePath("ACTION", "IBKR", "NYSE", "AAPL:USD");
 
-        assertThat(pathUnderscore).isEqualTo("s3://datalake/ACTION/EUR/AAPL/");
-        assertThat(pathColon).isEqualTo("s3://datalake/ACTION/USD/AAPL/");
+        assertThat(pathUnderscore).isEqualTo("s3://datalake/ACTION/IBKR/NYSE/EUR/AAPL/");
+        assertThat(pathColon).isEqualTo("s3://datalake/ACTION/IBKR/NYSE/USD/AAPL/");
     }
 
     @Test
     void sanitizesSegmentsAndFallsBackToUnknownCurrencyWhenMissing() {
-        String path = config.resolveTablePath(" Action  ", "  T TE @#  ");
+        String path = config.resolveTablePath(" Action  ", "  ", "  ", "  T TE @#  ");
 
-        assertThat(path).isEqualTo("s3://datalake/ACTION/UNKNOWN/T_TE___/");
+        assertThat(path).isEqualTo("s3://datalake/ACTION/UNKNOWN/UNKNOWN/UNKNOWN/T_TE___/");
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure Delta Lake table paths include broker (and venue) segments so data is organized per broker/venue in the storage layout.
- Make export and path-building code produce consistent paths for ACTION/CRYPTO/ETF examples like `.../STOCK/IBKR/NYSE/USD/AAPL`.

### Description
- Change `DeltaLakeConfig.resolveTablePath` signature to `resolveTablePath(String assetCategory, String broker, String venue, String symbol)` and include `broker`/`venue` segments in the returned path.
- Update `DeltaLakeExporter` to call the new `resolveTablePath` and pass `job.getBroker()` and `job.getVenue()` when resolving the effective table path.
- Update `DeltaPathBuilder.buildPath` to accept a `broker` parameter and include it in the returned path, and update `IbkrImportService` to pass `job.getBroker()` when building `deltaPath`.
- Adjust `DeltaLakeCandleReader.buildDeltaPath` to include a broker segment (defaulting to `UNKNOWN`) and add null-safety in `sanitizeSegment`.
- Update unit test `DeltaLakeConfigTest` expectations to reflect the new path layout including `broker` and `venue` segments.

### Testing
- Updated unit test `DeltaLakeConfigTest` to cover the new path layout with broker and venue segments.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694932a59e90832396a4d465844b540e)