### PR TITLE
Add MockMvc tests for Universe, DataImport and key controllers

### DIFF
--- a/src/test/java/finance/project/api/controllers/BacktestControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/BacktestControllerTest.java
@@ -1,0 +1,134 @@
+package finance.project.api.controllers;
+
+import finance.project.api.services.CandleCacheManager;
+import finance.project.api.services.CandleService;
+import finance.project.api.services.PerformanceService;
+import finance.project.api.services.StrategyManager;
+import finance.project.api.services.TA4JService;
+import finance.project.api.services.TradeCompletedMapper;
+import finance.project.api.services.TradeCompletedService;
+import finance.project.api.services.TradeService;
+import finance.project.api.services.VolumeBasedRolloverService;
+import finance.project.api.services.SymbolService;
+import finance.project.api.strategies.volume.EmaVolumeStrategy;
+import finance.project.api.utils.StrategyResult;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BacktestController.class)
+class BacktestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TA4JService ta4JService;
+
+    @MockBean
+    private VolumeBasedRolloverService volumeBasedRolloverService;
+
+    @MockBean
+    private EmaVolumeStrategy emaVolumeStrategy;
+
+    @MockBean
+    private SymbolService symbolService;
+
+    @MockBean
+    private CandleService candleService;
+
+    @MockBean
+    private StrategyManager strategyManager;
+
+    @MockBean
+    private PerformanceService performanceService;
+
+    @MockBean
+    private TradeService tradeService;
+
+    @MockBean
+    private TradeCompletedService tradeCompletedService;
+
+    @MockBean
+    private TradeCompletedMapper tradeCompletedMapper;
+
+    @MockBean
+    private CandleCacheManager candleCacheManager;
+
+    @Test
+    void runStrategyReturnsConfirmationMessage() throws Exception {
+        given(strategyManager.runStrategies("AAPL", "1d", 1000))
+                .willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/run-strategy")
+                        .param("symbol", "AAPL")
+                        .param("timeframe", "1d")
+                        .param("period", "1000")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Stratégies exécutées sur AAPL 1d"));
+    }
+
+    @Test
+    void runTrendFollowingReturnsPayload() throws Exception {
+        StrategyResult result = StrategyResult.builder()
+                .signals(List.of())
+                .completedTrades(List.of())
+                .performance(Map.of("winRate", 0.75))
+                .nameStrategy("TrendFollowing")
+                .build();
+
+        given(strategyManager.runTrendFollowing(anyString(), anyString(), anyInt(), anyDouble(), anyDouble()))
+                .willReturn(result);
+
+        mockMvc.perform(get("/trend-following")
+                        .param("symbol", "AAPL")
+                        .param("timeframe", "1d")
+                        .param("comparedSymbol", "MSFT")
+                        .param("period", "1000")
+                        .param("slPercent", "1.0")
+                        .param("rrRatio", "2.0")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.performance.winRate", is(0.75)))
+                .andExpect(jsonPath("$.nameStrategy", is("TrendFollowing")));
+
+        verify(tradeService).saveTrades(anyString(), any());
+        verify(tradeCompletedService).saveCompletedTrades(anyString(), any(), anyString());
+        verify(performanceService).savePerformance(anyString(), anyString(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void getTradesByStrategyReturnsNoContentWhenEmpty() throws Exception {
+        given(tradeCompletedService.getTradesByStrategyAndRunId("TrendFollowing", "run-1"))
+                .willReturn(List.of());
+
+        mockMvc.perform(get("/get-trades-strategy")
+                        .param("strategyName", "TrendFollowing")
+                        .param("runId", "run-1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        verifyNoInteractions(tradeCompletedMapper);
+    }
+}

--- a/src/test/java/finance/project/api/controllers/MarketScannerControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/MarketScannerControllerTest.java
@@ -1,0 +1,86 @@
+package finance.project.api.controllers;
+
+import finance.project.api.model.market.MarketScanItem;
+import finance.project.api.model.market.OhlcBar;
+import finance.project.api.services.market.HistoricalDataService;
+import finance.project.api.services.market.MarketScannerService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MarketScannerController.class)
+class MarketScannerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MarketScannerService marketScannerService;
+
+    @MockBean
+    private HistoricalDataService historicalDataService;
+
+    @Test
+    void scanTopLosersReturnsItems() throws Exception {
+        given(marketScannerService.scanTopLosersByRegion("US", "EQUITY", 1_000_000.0, 5))
+                .willReturn(List.of(
+                        new MarketScanItem("AAPL", "Apple", "NASDAQ", 150.0, -2.5, 2_000_000_000.0, "USD", "TECH", null, null)
+                ));
+
+        mockMvc.perform(get("/api/market/scans/top-losers")
+                        .param("region", "US")
+                        .param("assetClass", "EQUITY")
+                        .param("minMarketCap", "1000000")
+                        .param("limit", "5")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()", is(1)))
+                .andExpect(jsonPath("$[0].symbol", is("AAPL")))
+                .andExpect(jsonPath("$[0].changePct", is(-2.5)));
+    }
+
+    @Test
+    void getOhlcReturnsBars() throws Exception {
+        given(historicalDataService.getHistoricalOhlc(anyString(), any(), any(), any(), any()))
+                .willReturn(List.of(
+                        new OhlcBar(Instant.parse("2024-01-01T00:00:00Z"), 100.0, 110.0, 95.0, 105.0, 1000.0)
+                ));
+
+        mockMvc.perform(get("/api/market/ohlc")
+                        .param("symbol", "AAPL")
+                        .param("start", "2024-01-01T00:00:00Z")
+                        .param("end", "2024-01-02T00:00:00Z")
+                        .param("timeframe", "1d")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()", is(1)))
+                .andExpect(jsonPath("$[0].open", is(100.0)))
+                .andExpect(jsonPath("$[0].close", is(105.0)));
+    }
+
+    @Test
+    void getOhlcReturnsBadRequestOnInvalidDate() throws Exception {
+        mockMvc.perform(get("/api/market/ohlc")
+                        .param("symbol", "AAPL")
+                        .param("start", "invalid-date")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error", is("Invalid date format. Use ISO-8601.")));
+    }
+}

--- a/src/test/java/finance/project/api/controllers/StrategyControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/StrategyControllerTest.java
@@ -1,0 +1,41 @@
+package finance.project.api.controllers;
+
+import finance.project.api.services.StrategyDiscoveryService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StrategyController.class)
+class StrategyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StrategyDiscoveryService strategyDiscoveryService;
+
+    @Test
+    void listStrategiesReturnsNames() throws Exception {
+        given(strategyDiscoveryService.getAvailableStrategies())
+                .willReturn(List.of("TrendFollowing", "ExplosionGrid"));
+
+        mockMvc.perform(get("/all-name-strategies")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()", is(2)))
+                .andExpect(jsonPath("$[0]", is("TrendFollowing")))
+                .andExpect(jsonPath("$[1]", is("ExplosionGrid")));
+    }
+}

--- a/src/test/java/finance/project/api/controllers/TradesControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/TradesControllerTest.java
@@ -1,0 +1,62 @@
+package finance.project.api.controllers;
+
+import finance.project.api.model.TradeViewDTO;
+import finance.project.api.services.BrokerTradeService;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TradesController.class)
+class TradesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BrokerTradeService brokerTradeService;
+
+    @Test
+    void listTradesReturnsResults() throws Exception {
+        given(brokerTradeService.brokerId()).willReturn("IBKR");
+        given(brokerTradeService.listOpenTrades()).willReturn(List.of(
+                new TradeViewDTO(
+                        "IBKR",
+                        "DU123",
+                        "AAPL",
+                        "Apple Inc.",
+                        "STK",
+                        "USD",
+                        "SMART",
+                        12345,
+                        10,
+                        150.0,
+                        155.0,
+                        1550.0,
+                        50.0,
+                        10.0,
+                        Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
+                )
+        ));
+
+        mockMvc.perform(get("/trades")
+                        .param("broker", "IBKR")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()", is(1)))
+                .andExpect(jsonPath("$[0].symbol", is("AAPL")))
+                .andExpect(jsonPath("$[0].broker", is("IBKR")));
+    }
+}

--- a/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerTest.java
+++ b/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerTest.java
@@ -1,0 +1,126 @@
+package finance.project.api.dataimport.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import finance.project.api.dataimport.DataImportJob;
+import finance.project.api.dataimport.DataImportService;
+import finance.project.api.dataimport.dto.DataImportRequest;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DataImportJobController.class)
+class DataImportJobControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private DataImportService dataImportService;
+
+    @Test
+    void createJobReturnsAcceptedResponse() throws Exception {
+        DataImportRequest request = new DataImportRequest(
+                "IBKR",
+                "AAPL",
+                "1d",
+                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2024-01-10T00:00:00Z"),
+                "HISTORICAL",
+                "NYSE",
+                "UTC",
+                "IGNORE",
+                "NONE",
+                "EQUITY"
+        );
+
+        DataImportJob job = buildJob("job-1");
+
+        given(dataImportService.createJob(request)).willReturn(job);
+
+        mockMvc.perform(post("/api/data-import/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isAccepted())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id", is("job-1")))
+                .andExpect(jsonPath("$.broker", is("IBKR")))
+                .andExpect(jsonPath("$.status", is("PENDING")));
+    }
+
+    @Test
+    void createJobRejectsInvalidDateRange() throws Exception {
+        DataImportRequest request = new DataImportRequest(
+                "IBKR",
+                "AAPL",
+                "1d",
+                Instant.parse("2024-02-01T00:00:00Z"),
+                Instant.parse("2024-01-01T00:00:00Z"),
+                "HISTORICAL",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        mockMvc.perform(post("/api/data-import/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getJobReturnsResponse() throws Exception {
+        DataImportJob job = buildJob("job-2");
+        given(dataImportService.getJob("job-2")).willReturn(Optional.of(job));
+
+        mockMvc.perform(get("/api/data-import/jobs/job-2")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id", is("job-2")))
+                .andExpect(jsonPath("$.symbol", is("AAPL")))
+                .andExpect(jsonPath("$.status", is("PENDING")));
+    }
+
+    @Test
+    void getJobReturnsNotFound() throws Exception {
+        given(dataImportService.getJob("missing")).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/data-import/jobs/missing")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    private DataImportJob buildJob(String id) {
+        DataImportJob job = new DataImportJob();
+        job.setId(id);
+        job.setBroker("IBKR");
+        job.setSymbol("AAPL");
+        job.setTimeframe("1d");
+        job.setStartDate(Instant.parse("2024-01-01T00:00:00Z"));
+        job.setEndDate(Instant.parse("2024-01-10T00:00:00Z"));
+        job.setSourceType("HISTORICAL");
+        job.setStatus(DataImportJob.Status.PENDING);
+        job.setProgress(0);
+        job.setCreatedAt(Instant.parse("2024-01-01T00:00:00Z"));
+        job.setUpdatedAt(Instant.parse("2024-01-01T00:00:00Z"));
+        return job;
+    }
+}

--- a/src/test/java/finance/project/api/universe/api/UniverseControllerTest.java
+++ b/src/test/java/finance/project/api/universe/api/UniverseControllerTest.java
@@ -1,0 +1,132 @@
+package finance.project.api.universe.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import finance.project.api.universe.dto.UniverseCatalogDTO;
+import finance.project.api.universe.dto.UniverseDetailsDTO;
+import finance.project.api.universe.dto.UniverseImportRequest;
+import finance.project.api.universe.dto.UniverseImportResponse;
+import finance.project.api.universe.service.UniverseService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UniverseController.class)
+class UniverseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UniverseService universeService;
+
+    @Test
+    void getCatalogReturnsUniverses() throws Exception {
+        List<UniverseCatalogDTO> catalog = List.of(
+                new UniverseCatalogDTO("us-equities", "US Equities", "EQUITY", "IBKR", 1200, true),
+                new UniverseCatalogDTO("crypto", "Crypto", "CRYPTO", "BINANCE", 200, false)
+        );
+
+        given(universeService.getCatalog()).willReturn(catalog);
+
+        mockMvc.perform(get("/api/universes/catalog")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()", is(2)))
+                .andExpect(jsonPath("$[0].code", is("us-equities")))
+                .andExpect(jsonPath("$[0].importable", is(true)))
+                .andExpect(jsonPath("$[1].provider", is("BINANCE")));
+    }
+
+    @Test
+    void importUniverseAcceptsRequest() throws Exception {
+        UniverseImportRequest request = new UniverseImportRequest(
+                "us-equities",
+                "IBKR",
+                "1d",
+                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2024-01-10T00:00:00Z"),
+                "NYSE",
+                "EQUITY"
+        );
+
+        UniverseImportResponse response = new UniverseImportResponse(42L, "us-equities", "EQUITY", "IBKR");
+
+        given(universeService.importUniverse(request)).willReturn(response);
+
+        mockMvc.perform(post("/api/universes/import")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isAccepted())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.universeId", is(42)))
+                .andExpect(jsonPath("$.code", is("us-equities")))
+                .andExpect(jsonPath("$.provider", is("IBKR")));
+    }
+
+    @Test
+    void importUniverseValidatesPayload() throws Exception {
+        UniverseImportRequest invalidRequest = new UniverseImportRequest(
+                "",
+                "",
+                "",
+                null,
+                null,
+                null,
+                null
+        );
+
+        mockMvc.perform(post("/api/universes/import")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getUniverseReturnsDetails() throws Exception {
+        UniverseDetailsDTO details = new UniverseDetailsDTO(
+                10L,
+                "us-equities",
+                "US Equities",
+                "EQUITY",
+                "IBKR",
+                List.of("AAPL", "MSFT")
+        );
+
+        given(universeService.getUniverseDetails("us-equities")).willReturn(Optional.of(details));
+
+        mockMvc.perform(get("/api/universes/us-equities")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code", is("us-equities")))
+                .andExpect(jsonPath("$.symbols.length()", is(2)))
+                .andExpect(jsonPath("$.symbols[0]", is("AAPL")));
+    }
+
+    @Test
+    void getUniverseReturnsNotFound() throws Exception {
+        given(universeService.getUniverseDetails("missing")).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/universes/missing")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve controller-level test coverage for core REST endpoints by adding MockMvc tests for important controllers and flows.
- Verify request validation (`@Valid`) and error handling paths for import endpoints and date parsing.
- Standardize test patterns to match existing controller tests such as `CandleControllerTest` and `SymbolControllerTest` using `@WebMvcTest` and mocked services.

### Description
- Added new MockMvc test classes: `UniverseControllerTest`, `DataImportJobControllerTest`, `StrategyControllerTest`, `BacktestControllerTest`, `TradesControllerTest`, and `MarketScannerControllerTest` that exercise endpoints like `/api/universes/catalog`, `/api/universes/import`, `/api/universes/{code}`, `POST /api/data-import/jobs`, and `GET /api/data-import/jobs/{id}`.
- Tests use `@WebMvcTest`, `@MockBean` to mock dependent services (e.g. `UniverseService`, `DataImportService`, `StrategyDiscoveryService`, `StrategyManager`, `BrokerTradeService`, `MarketScannerService`, etc.) and `ObjectMapper` to build JSON payloads.
- Assertions cover HTTP statuses, `Content-Type`, JSON payload fields via `jsonPath`, and validation/error responses (e.g. bad requests for invalid payloads or date parsing errors).
- Test implementations follow existing controller test patterns (mocking, `given(...)`, `mockMvc.perform(...)`, and `andExpect(...)`).

### Testing
- Added unit test sources for multiple controllers but did not run the test suite in this environment.
- Tests assert expected HTTP responses and JSON payload shapes using MockMvc and mocked services.
- No automated test failures were observed because tests were not executed here.
- The new test files were committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dd0aebe88323b7a75ce20f4696d3)