### PR TITLE
Add @DataJpaTest for UniverseRepository and candle availability projection

### DIFF
--- a/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionTest.java
+++ b/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionTest.java
@@ -1,0 +1,69 @@
+package finance.project.api.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import finance.project.api.entities.Candle;
+import finance.project.api.entities.Symbol;
+import finance.project.api.repositories.projections.CandleAvailabilityProjection;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class CandleAvailabilityProjectionTest {
+
+    @Autowired
+    private CandleRepository candleRepository;
+
+    @Autowired
+    private SymbolRepository symbolRepository;
+
+    @Test
+    void findAvailabilitySummaryAggregatesCandles() {
+        Symbol symbol = symbolRepository.save(Symbol.builder()
+                .symbol("AAPL")
+                .name("Apple Inc.")
+                .market("NASDAQ")
+                .build());
+
+        LocalDateTime start = LocalDateTime.of(2024, 1, 1, 0, 0);
+        LocalDateTime end = LocalDateTime.of(2024, 1, 2, 0, 0);
+
+        candleRepository.save(Candle.builder()
+                .symbol(symbol)
+                .timeframe("daily")
+                .date(start)
+                .open(BigDecimal.ONE)
+                .close(BigDecimal.ONE)
+                .high(BigDecimal.ONE)
+                .low(BigDecimal.ONE)
+                .build());
+
+        candleRepository.save(Candle.builder()
+                .symbol(symbol)
+                .timeframe("daily")
+                .date(end)
+                .open(BigDecimal.TEN)
+                .close(BigDecimal.TEN)
+                .high(BigDecimal.TEN)
+                .low(BigDecimal.TEN)
+                .build());
+
+        List<CandleAvailabilityProjection> projections = candleRepository.findAvailabilitySummary();
+
+        assertThat(projections).hasSize(1);
+
+        CandleAvailabilityProjection projection = projections.get(0);
+        assertThat(projection.getSymbol()).isEqualTo("AAPL");
+        assertThat(projection.getBroker()).isEqualTo("DB");
+        assertThat(projection.getTimeframe()).isEqualTo("daily");
+        assertThat(projection.getStart()).isEqualTo(start);
+        assertThat(projection.getEnd()).isEqualTo(end);
+        assertThat(projection.getCount()).isEqualTo(2L);
+        assertThat(projection.getUpdatedAt()).isEqualTo(end);
+        assertThat(projection.getMarketType()).isEqualTo("NASDAQ");
+    }
+}

--- a/src/test/java/finance/project/api/universe/UniverseRepositoryTest.java
+++ b/src/test/java/finance/project/api/universe/UniverseRepositoryTest.java
@@ -1,0 +1,36 @@
+package finance.project.api.universe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class UniverseRepositoryTest {
+
+    @Autowired
+    private UniverseRepository universeRepository;
+
+    @Test
+    void findByCodeReturnsMatchingUniverse() {
+        Universe universe = Universe.builder()
+                .code("core-equities")
+                .name("Core Equities")
+                .type(UniverseType.EQUITY)
+                .provider("internal")
+                .createdAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        universeRepository.save(universe);
+
+        Optional<Universe> result = universeRepository.findByCode("core-equities");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo("Core Equities");
+        assertThat(result.get().getProvider()).isEqualTo("internal");
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide repository-level coverage for `UniverseRepository.findByCode` to guard against regressions in universe lookup.
- Verify the custom projection query `CandleRepository.findAvailabilitySummary` maps correctly to `CandleAvailabilityProjection`.
- Exercise JPA mappings and aggregation logic against the H2 test database with minimal fixtures.

### Description

- Add `src/test/java/finance/project/api/universe/UniverseRepositoryTest.java` with a `@DataJpaTest` that saves a `Universe` and asserts `findByCode` returns the persisted entity.
- Add `src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionTest.java` with a `@DataJpaTest` that persists a `Symbol` and two `Candle` rows then asserts fields returned by `findAvailabilitySummary` (including `symbol`, `broker`, `timeframe`, `start`, `end`, `count`, `updatedAt`, `marketType`).
- Tests use existing H2-backed test scope and entity builders to create minimal fixtures without modifying production code.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949de7588388323a303119429a3b129)