### PR TITLE
Add UniverseController integration tests and 400 handler

### DIFF
--- a/src/main/java/finance/project/api/universe/api/UniverseController.java
+++ b/src/main/java/finance/project/api/universe/api/UniverseController.java
@@ -7,8 +7,10 @@ import finance.project.api.universe.dto.UniverseImportResponse;
 import finance.project.api.universe.service.UniverseService;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,5 +44,10 @@ public class UniverseController {
         return universeService.getUniverseDetails(code)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
     }
 }

--- a/src/test/java/finance/project/api/universe/api/UniverseControllerIntegrationTest.java
+++ b/src/test/java/finance/project/api/universe/api/UniverseControllerIntegrationTest.java
@@ -1,0 +1,144 @@
+package finance.project.api.universe.api;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import finance.project.api.entities.Symbol;
+import finance.project.api.repositories.SymbolRepository;
+import finance.project.api.universe.Universe;
+import finance.project.api.universe.UniverseRepository;
+import finance.project.api.universe.UniverseType;
+import finance.project.api.universe.client.CoingeckoUniverseClient;
+import finance.project.api.universe.dto.UniverseImportRequest;
+import finance.project.api.universe.service.UniverseImportRunner;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UniverseControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UniverseRepository universeRepository;
+
+    @Autowired
+    private SymbolRepository symbolRepository;
+
+    @MockBean
+    private CoingeckoUniverseClient coingeckoUniverseClient;
+
+    @MockBean
+    private UniverseImportRunner universeImportRunner;
+
+    @BeforeEach
+    void setUp() {
+        universeRepository.deleteAll();
+        symbolRepository.deleteAll();
+        when(coingeckoUniverseClient.listCategories()).thenReturn(List.of());
+
+        Symbol symbol = symbolRepository.save(Symbol.builder()
+                .symbol("AAPL")
+                .name("Apple")
+                .market("EQUITY")
+                .build());
+
+        Universe universe = Universe.builder()
+                .code("TECH")
+                .name("Tech Universe")
+                .type(UniverseType.EQUITY)
+                .provider("CSV_MANUAL")
+                .build();
+        universe.addSymbol(symbol);
+        symbol.getUniverses().add(universe);
+        universeRepository.save(universe);
+    }
+
+    @Test
+    void getCatalogReturnsNonEmptyList() throws Exception {
+        mockMvc.perform(get("/api/universes/catalog"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isNotEmpty());
+    }
+
+    @Test
+    void importUniverseWithValidDatesReturnsAccepted() throws Exception {
+        UniverseImportRequest request = new UniverseImportRequest(
+                "AAPLMSFT",
+                "BINANCE",
+                "1d",
+                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2024-02-01T00:00:00Z"),
+                null,
+                null
+        );
+
+        doNothing().when(universeImportRunner).runUniverseImport(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+
+        mockMvc.perform(post("/api/universes/import")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.universeId").isNumber())
+                .andExpect(jsonPath("$.code").value("AAPLMSFT"))
+                .andExpect(jsonPath("$.type").value("EQUITY"))
+                .andExpect(jsonPath("$.provider").value("CSV_MANUAL"));
+
+        verify(universeImportRunner).runUniverseImport(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void importUniverseWithInvalidDatesReturnsBadRequest() throws Exception {
+        UniverseImportRequest request = new UniverseImportRequest(
+                "AAPLMSFT",
+                "BINANCE",
+                "1d",
+                Instant.parse("2024-02-01T00:00:00Z"),
+                Instant.parse("2024-01-01T00:00:00Z"),
+                null,
+                null
+        );
+
+        mockMvc.perform(post("/api/universes/import")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getUniverseReturnsOkWhenExists() throws Exception {
+        mockMvc.perform(get("/api/universes/TECH"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("TECH"))
+                .andExpect(jsonPath("$.symbols").isArray())
+                .andExpect(jsonPath("$.symbols[0]").value("AAPL"));
+    }
+
+    @Test
+    void getUniverseReturnsNotFoundWhenMissing() throws Exception {
+        mockMvc.perform(get("/api/universes/UNKNOWN"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide integration coverage for `UniverseController` endpoints under a Spring Boot test profile to catch regressions in universe catalog and import flows.
- Reduce external dependencies during tests by faking CoinGecko and async import runner to make tests deterministic and fast.
- Surface validation errors as HTTP 400 for `IllegalArgumentException` thrown by `UniverseService` to align controller responses with expected client behavior.
- Use an in-memory H2 test datasource so tests operate on a real JPA stack without external databases.

### Description
- Add an `@ExceptionHandler(IllegalArgumentException.class)` to `src/main/java/finance/project/api/universe/api/UniverseController.java` which returns `400` with a JSON message body.
- Add `src/test/java/finance/project/api/universe/api/UniverseControllerIntegrationTest.java` as a Spring Boot integration test annotated with `@SpringBootTest`, `@AutoConfigureMockMvc` and `@ActiveProfiles("test")` covering `/api/universes/catalog`, `/api/universes/import` (valid and invalid dates) and `/api/universes/{code}` (exists / missing).
- Mock external dependencies with `@MockBean` for `CoingeckoUniverseClient` and `UniverseImportRunner`, and prepare test fixtures programmatically in `@BeforeEach` by creating `Symbol` and `Universe` entities persisted to the H2 test DB.
- Rely on existing test configuration in `src/test/resources/application.yml` (H2) and assert `UniverseImportRunner.runUniverseImport(...)` is invoked using Mockito verification in the happy-path test.

### Testing
- Attempted to run the test class with `./mvnw -q -Dtest=UniverseControllerIntegrationTest test`, but the build run was interrupted and did not complete, so automated test results are not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3c9820208323988365ab3c5b7ef4)