### PR TITLE
Add failure coverage for CSV import tests

### DIFF
--- a/src/test/java/finance/project/api/dataimport/ingestion/CsvImportServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/CsvImportServiceTest.java
@@ -1,6 +1,7 @@
 package finance.project.api.dataimport.ingestion;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import finance.project.api.dataimport.DataImportJob;
 import java.time.Instant;
@@ -18,5 +19,22 @@ class CsvImportServiceTest {
 
         assertThatCode(() -> service.importGenericFile(job, Instant.EPOCH, Instant.EPOCH.plusSeconds(60)))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void importGenericFileDoesNotThrowWhenJobFieldsMissing() {
+        CsvImportService service = new CsvImportService();
+        DataImportJob job = new DataImportJob();
+
+        assertThatCode(() -> service.importGenericFile(job, Instant.EPOCH, Instant.EPOCH.plusSeconds(60)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void importGenericFileThrowsWhenJobIsNull() {
+        CsvImportService service = new CsvImportService();
+
+        assertThatThrownBy(() -> service.importGenericFile(null, Instant.EPOCH, Instant.EPOCH.plusSeconds(60)))
+                .isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportServiceTest.java
@@ -1,6 +1,7 @@
 package finance.project.api.dataimport.ingestion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -97,6 +98,23 @@ class DatabentoCsvImportServiceTest {
         when(candleService.loadCsvCME("ES", "1min", "data_2024-02")).thenReturn(List.of());
 
         service.importCsv(job, start, end, null);
+
+        verify(candleService, never()).saveCandlesToDatabase(anyList(), eq("ES"), eq("1min"));
+        verify(deltaLakeExporter, never()).exportCandlesToDelta(eq(job), anyList());
+        verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
+    }
+
+    @Test
+    void importCsvStopsWhenLoadThrows() {
+        DataImportJob job = job("ES", "1min");
+        Instant start = Instant.parse("2024-02-01T00:00:00Z");
+        Instant end = Instant.parse("2024-02-02T00:00:00Z");
+
+        when(candleService.loadCsvCME("ES", "1min", "data_2024-02"))
+                .thenThrow(new RuntimeException("boom"));
+
+        assertThatThrownBy(() -> service.importCsv(job, start, end, null))
+                .isInstanceOf(RuntimeException.class);
 
         verify(candleService, never()).saveCandlesToDatabase(anyList(), eq("ES"), eq("1min"));
         verify(deltaLakeExporter, never()).exportCandlesToDelta(eq(job), anyList());


### PR DESCRIPTION
### Motivation

- Extend the existing ingestion test patterns to cover error and edge cases for CSV import flows.  
- Ensure that downstream persistence and export (`CandleService` / `DeltaLakeExporter`) are not invoked when CSV loading fails or returns no data.  
- Add defensive test coverage for `CsvImportService` when job fields are missing or the job is `null`.  
- Make Databento CSV behavior explicit when the CSV loader throws an exception.

### Description

- Added `importGenericFileDoesNotThrowWhenJobFieldsMissing` and `importGenericFileThrowsWhenJobIsNull` to `src/test/java/finance/project/api/dataimport/ingestion/CsvImportServiceTest.java` to validate behavior with partial or missing `DataImportJob` data and a `null` job.  
- Added `importCsvStopsWhenLoadThrows` to `src/test/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportServiceTest.java` to simulate a `RuntimeException` from `candleService.loadCsvCME` and assert that no calls to `saveCandlesToDatabase`, `exportCandlesToDelta`, or aggregation are performed.  
- Updated test imports to include `assertThatThrownBy` for exception assertions.  
- Changes are limited to unit tests and do not alter production code behavior.

### Testing

- New unit tests added: `CsvImportServiceTest` (2 new tests) and `DatabentoCsvImportServiceTest` (1 new test).  
- Tests use JUnit 5, Mockito, and AssertJ for mocking and assertions.  
- No automated test suite was executed as part of this change.  
- Local compilation of tests was not reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3ca442908323a582d7016327a565)