### PR TITLE
Stabilize test configuration and data import status handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ database/*.db
 *application*.properties
 *local.properties
 !src/main/resources/application.properties
+!src/test/resources/application-test.properties
 
 # Local configuration overrides
 src/main/resources/application-local.properties

--- a/scripts/install-ibkr-jars.sh
+++ b/scripts/install-ibkr-jars.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+jar_dir="$repo_root/jar"
+
+mvn install:install-file \
+  -Dfile="$jar_dir/protobuf-java-4.29.3.jar" \
+  -DgroupId=com.ib \
+  -DartifactId=tws-api-proto \
+  -Dversion=10.40 \
+  -Dpackaging=jar

--- a/src/main/java/finance/project/api/Application.java
+++ b/src/main/java/finance/project/api/Application.java
@@ -5,14 +5,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableAsync
 @EntityScan({"finance.project.api.entities", "finance.project.api.dataimport", "finance.project.api.live", "finance.project.api.universe"})
-@EnableJpaRepositories({"finance.project.api.repositories", "finance.project.api.dataimport", "finance.project.api.live", "finance.project.api.universe"})
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/finance/project/api/config/DeltaLakeConfig.java
+++ b/src/main/java/finance/project/api/config/DeltaLakeConfig.java
@@ -65,7 +65,7 @@ public class DeltaLakeConfig {
         if (value == null) {
             return "UNKNOWN";
         }
-        String sanitized = StringUtils.trimAllWhitespace(value).replaceAll("[^a-zA-Z0-9_-]", "_");
+        String sanitized = StringUtils.trimWhitespace(value).replaceAll("[^a-zA-Z0-9_-]", "_");
         return sanitized.isEmpty() ? "UNKNOWN" : sanitized.toUpperCase();
     }
 

--- a/src/main/java/finance/project/api/config/ValidationErrorHandler.java
+++ b/src/main/java/finance/project/api/config/ValidationErrorHandler.java
@@ -1,0 +1,28 @@
+package finance.project.api.config;
+
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ValidationErrorHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationErrors(MethodArgumentNotValidException ex) {
+        List<Map<String, String>> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(this::toErrorPayload)
+                .toList();
+        return ResponseEntity.badRequest().body(Map.of("errors", errors));
+    }
+
+    private Map<String, String> toErrorPayload(FieldError error) {
+        return Map.of(
+                "field", error.getField(),
+                "defaultMessage", error.getDefaultMessage()
+        );
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
@@ -65,10 +65,7 @@ public class DataImportJobRunner {
         }
 
         try {
-            // Passe en RUNNING
-            job.setStatus(DataImportJob.Status.RUNNING);
-            job.setUpdatedAt(Instant.now());
-            jobRepository.save(job);
+            transitionToRunning(job);
 
             log.info("[DataImport] Job {} RUNNING for {} {} {} {} {}",
                     job.getId(), job.getBroker(), job.getSymbol(),
@@ -78,27 +75,20 @@ public class DataImportJobRunner {
             boolean anySuccess = executeJob(job);
 
             if (anySuccess) {
-                job.setStatus(DataImportJob.Status.SUCCESS);
-                job.setMessage("Import completed");
+                markSuccess(job);
                 log.info("[DataImport] Job {} SUCCESS", job.getId());
             } else {
                 job.setStatus(DataImportJob.Status.FAILED);
-                job.setMessage("No data imported from any provider");
+                job.setProgress(Math.min(job.getProgress(), 99));
+                job.setMessage("Aucune donnée disponible pour la période demandée");
+                job.setUpdatedAt(Instant.now());
+                jobRepository.save(job);
                 log.warn("[DataImport] Job {} FAILED - no provider returned data", job.getId());
             }
 
-            job.setUpdatedAt(Instant.now());
-            jobRepository.save(job);
-
         } catch (Exception e) {
             log.error("[DataImport] Job {} FAILED: {}", job.getId(), e.getMessage(), e);
-
-            job.setStatus(DataImportJob.Status.FAILED);
-            job.setUpdatedAt(Instant.now());
-            job.setMessage(
-                    Optional.ofNullable(e.getMessage()).orElse("Unexpected error in async import")
-            );
-            jobRepository.save(job);
+            markFailure(job, e);
         }
     }
 

--- a/src/main/java/finance/project/api/entities/Performance.java
+++ b/src/main/java/finance/project/api/entities/Performance.java
@@ -21,7 +21,9 @@ public class Performance {
     private String strategyName;
 
     private String metric; // Ex: "winRate", "profitFactor"
-    private double value;
+
+    @Column(name = "metric_value")
+    private double metricValue;
 
     /**
      * Identifier to group all metrics of the same strategy run. This allows

--- a/src/main/java/finance/project/api/services/PerformanceService.java
+++ b/src/main/java/finance/project/api/services/PerformanceService.java
@@ -24,7 +24,7 @@ public class PerformanceService {
                 .comparedSymbol(comparedSymbol)
                 .timeframe(timeframe)
                 .metric(null)
-                .value(0.0)
+                .metricValue(0.0)
                 .winCount(toBigDecimal(performance.get("winCount")))
                 .lossCount(toBigDecimal(performance.get("lossCount")))
                 .totalReturn(toBigDecimal(performance.get("totalReturn")))

--- a/src/test/java/finance/project/api/ApplicationTests.java
+++ b/src/test/java/finance/project/api/ApplicationTests.java
@@ -2,8 +2,10 @@ package finance.project.api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ApplicationTests {
 
 	@Test

--- a/src/test/java/finance/project/api/ComparisonControllerTest.java
+++ b/src/test/java/finance/project/api/ComparisonControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -38,6 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ComparisonController.class)
 @ExtendWith(SpringExtension.class)
 @Import(ComServiceTestConfig.class)
+@ActiveProfiles("test")
 public class ComparisonControllerTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/bootstrap/BootstrapDataTest.java
+++ b/src/test/java/finance/project/api/bootstrap/BootstrapDataTest.java
@@ -5,12 +5,16 @@ import finance.project.api.repositories.SymbolRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class BootstrapDataTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/controllers/BacktestControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/BacktestControllerTest.java
@@ -10,6 +10,7 @@ import finance.project.api.services.TradeCompletedService;
 import finance.project.api.services.TradeService;
 import finance.project.api.services.VolumeBasedRolloverService;
 import finance.project.api.services.SymbolService;
+import finance.project.api.services.MarketDataService;
 import finance.project.api.strategies.volume.EmaVolumeStrategy;
 import finance.project.api.utils.StrategyResult;
 import java.util.Collections;
@@ -20,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.core.Is.is;
@@ -36,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BacktestController.class)
+@ActiveProfiles("test")
 class BacktestControllerTest {
 
     @Autowired
@@ -58,6 +61,9 @@ class BacktestControllerTest {
 
     @MockBean
     private StrategyManager strategyManager;
+
+    @MockBean
+    private MarketDataService marketDataService;
 
     @MockBean
     private PerformanceService performanceService;

--- a/src/test/java/finance/project/api/controllers/CandleControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/CandleControllerTest.java
@@ -1,14 +1,23 @@
 package finance.project.api.controllers;
 
 import finance.project.api.model.CandleDTO;
+import finance.project.api.services.BinanceService;
+import finance.project.api.services.CandleAggregationService;
 import finance.project.api.services.CandleService;
+import finance.project.api.services.CurrencyLayerService;
+import finance.project.api.services.DeltaLakeCandleReader;
+import finance.project.api.services.MarketstackService;
 import finance.project.api.services.SymbolService;
+import finance.project.api.services.TradeCompletedMapper;
+import finance.project.api.services.TradeCompletedService;
+import finance.project.api.services.VolumeBasedRolloverService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 
 import finance.project.api.model.SymbolDTO;
 import org.springframework.test.web.servlet.MvcResult;
@@ -24,12 +33,37 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(CandleController.class)
+@ActiveProfiles("test")
 public class CandleControllerTest {
     @Autowired
     MockMvc mockMvc;
 
     @MockBean
     CandleService candleService;
+
+    @MockBean
+    MarketstackService marketstackService;
+
+    @MockBean
+    CurrencyLayerService currencyLayerService;
+
+    @MockBean
+    CandleAggregationService candleAggregationService;
+
+    @MockBean
+    VolumeBasedRolloverService volumeBasedRolloverService;
+
+    @MockBean
+    TradeCompletedService tradeCompletedService;
+
+    @MockBean
+    TradeCompletedMapper tradeCompletedMapper;
+
+    @MockBean
+    DeltaLakeCandleReader deltaLakeCandleReader;
+
+    @MockBean
+    BinanceService binanceService;
 
     @MockBean
     SymbolService symbolService;

--- a/src/test/java/finance/project/api/controllers/MarketScannerControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/MarketScannerControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.core.Is.is;
@@ -23,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MarketScannerController.class)
+@ActiveProfiles("test")
 class MarketScannerControllerTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/controllers/StrategyControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/StrategyControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.core.Is.is;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(StrategyController.class)
+@ActiveProfiles("test")
 class StrategyControllerTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/controllers/SymbolControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/SymbolControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +27,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @WebMvcTest(SymbolController.class)
+@ActiveProfiles("test")
 class SymbolControllerTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/controllers/TradesControllerTest.java
+++ b/src/test/java/finance/project/api/controllers/TradesControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.core.Is.is;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TradesController.class)
+@ActiveProfiles("test")
 class TradesControllerTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/dataimport/DataImportJobControllerValidationTest.java
+++ b/src/test/java/finance/project/api/dataimport/DataImportJobControllerValidationTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
         "server.error.include-message=always",
         "server.error.include-binding-errors=always"
 })
+@ActiveProfiles("test")
 class DataImportJobControllerValidationTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
+++ b/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
@@ -66,9 +66,8 @@ class DataImportJobRunnerTest {
         when(jobRepository.findById("job-123")).thenReturn(Optional.of(job));
         when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        doAnswer(invocation -> null)
-                .when(binanceHistoricalService)
-                .fetchAndSave(any(), any(), any());
+        when(binanceHistoricalService.fetchAndSave(any(), any(), any()))
+                .thenReturn(true);
 
         runner.runJobAsync("job-123");
 

--- a/src/test/java/finance/project/api/dataimport/DataImportServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/DataImportServiceTest.java
@@ -43,6 +43,8 @@ class DataImportServiceTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null
         );
 
@@ -71,9 +73,11 @@ class DataImportServiceTest {
                 Instant.parse("2024-03-31T23:59:59Z"),
                 "CSV",
                 "data_2024-03",
+                "USD",
                 "UTC",
                 "merge",
-                "volume"
+                "volume",
+                "FX"
         );
 
         when(jobRepository.save(any(DataImportJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -95,6 +99,8 @@ class DataImportServiceTest {
                 Instant.parse("2024-01-02T00:00:00Z"),
                 Instant.parse("2024-01-01T00:00:00Z"),
                 "API",
+                null,
+                null,
                 null,
                 null,
                 null,
@@ -122,6 +128,8 @@ class DataImportServiceTest {
                 Instant.parse("2024-01-01T00:00:00Z"),
                 Instant.parse("2024-01-02T00:00:00Z"),
                 "API",
+                null,
+                null,
                 null,
                 null,
                 null,

--- a/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerIntegrationTest.java
+++ b/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -28,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class DataImportJobControllerIntegrationTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerTest.java
+++ b/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.core.Is.is;
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(DataImportJobController.class)
+@ActiveProfiles("test")
 class DataImportJobControllerTest {
 
     @Autowired
@@ -43,6 +45,7 @@ class DataImportJobControllerTest {
                 Instant.parse("2024-01-10T00:00:00Z"),
                 "HISTORICAL",
                 "NYSE",
+                "USD",
                 "UTC",
                 "IGNORE",
                 "NONE",
@@ -72,6 +75,7 @@ class DataImportJobControllerTest {
                 Instant.parse("2024-02-01T00:00:00Z"),
                 Instant.parse("2024-01-01T00:00:00Z"),
                 "HISTORICAL",
+                null,
                 null,
                 null,
                 null,

--- a/src/test/java/finance/project/api/dataimport/ingestion/BitgetHistoricalServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/BitgetHistoricalServiceTest.java
@@ -3,6 +3,7 @@ package finance.project.api.dataimport.ingestion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -77,7 +78,7 @@ class BitgetHistoricalServiceTest {
         boolean result = service.fetchAndSave(job, start, end);
 
         assertThat(result).isFalse();
-        verify(candleService, never()).saveCandlesToDatabase(anyList(), any(), any());
+        verify(candleService, never()).saveCandlesToDatabase(anyList(), anyString(), anyString());
         verify(deltaLakeExporter, never()).exportCandlesToDelta(any(), anyList());
         verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
     }
@@ -94,7 +95,7 @@ class BitgetHistoricalServiceTest {
         boolean result = service.fetchAndSave(job, start, end);
 
         assertThat(result).isFalse();
-        verify(candleService, never()).saveCandlesToDatabase(anyList(), any(), any());
+        verify(candleService, never()).saveCandlesToDatabase(anyList(), anyString(), anyString());
         verify(deltaLakeExporter, never()).exportCandlesToDelta(any(), anyList());
         verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
     }

--- a/src/test/java/finance/project/api/dataimport/ingestion/MexcHistoricalServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/MexcHistoricalServiceTest.java
@@ -3,6 +3,7 @@ package finance.project.api.dataimport.ingestion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -77,7 +78,7 @@ class MexcHistoricalServiceTest {
         boolean result = service.fetchAndSave(job, start, end);
 
         assertThat(result).isFalse();
-        verify(candleService, never()).saveCandlesToDatabase(anyList(), any(), any());
+        verify(candleService, never()).saveCandlesToDatabase(anyList(), anyString(), anyString());
         verify(deltaLakeExporter, never()).exportCandlesToDelta(any(), anyList());
         verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
     }
@@ -94,7 +95,7 @@ class MexcHistoricalServiceTest {
         boolean result = service.fetchAndSave(job, start, end);
 
         assertThat(result).isFalse();
-        verify(candleService, never()).saveCandlesToDatabase(anyList(), any(), any());
+        verify(candleService, never()).saveCandlesToDatabase(anyList(), anyString(), anyString());
         verify(deltaLakeExporter, never()).exportCandlesToDelta(any(), anyList());
         verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
     }

--- a/src/test/java/finance/project/api/live/LiveControllerTest.java
+++ b/src/test/java/finance/project/api/live/LiveControllerTest.java
@@ -19,10 +19,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 class LiveControllerTest {
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/finance/project/api/live/LiveSseHubTest.java
+++ b/src/test/java/finance/project/api/live/LiveSseHubTest.java
@@ -76,8 +76,16 @@ class LiveSseHubTest {
 
     @Override
     public synchronized void send(SseEventBuilder builder) throws IOException {
-      events.add((String) readField(builder, "name"));
-      data.add(readField(builder, "data"));
+      Object eventName = readField(builder, "name");
+      if (eventName == null) {
+        eventName = readField(builder, "event");
+      }
+      events.add((String) eventName);
+      Object payload = readField(builder, "data");
+      if (payload == null) {
+        payload = readField(builder, "dataToSend");
+      }
+      data.add(payload);
     }
 
     private Object readField(Object target, String fieldName) throws IOException {
@@ -105,7 +113,7 @@ class LiveSseHubTest {
           throw new IOException("Cannot access field " + fieldName, e);
         }
       }
-      throw new IOException("Field " + fieldName + " not found");
+      return null;
     }
   }
 }

--- a/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionTest.java
+++ b/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionTest.java
@@ -10,9 +10,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class CandleAvailabilityProjectionTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/repositories/ComparisonRepositoryTest.java
+++ b/src/test/java/finance/project/api/repositories/ComparisonRepositoryTest.java
@@ -4,7 +4,9 @@ import finance.project.api.entities.Comparison;
 import finance.project.api.entities.Symbol;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -13,6 +15,8 @@ import java.util.Optional;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class ComparisonRepositoryTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/universe/UniverseControllerValidationTest.java
+++ b/src/test/java/finance/project/api/universe/UniverseControllerValidationTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
         "server.error.include-message=always",
         "server.error.include-binding-errors=always"
 })
+@ActiveProfiles("test")
 class UniverseControllerValidationTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/universe/UniverseRepositoryTest.java
+++ b/src/test/java/finance/project/api/universe/UniverseRepositoryTest.java
@@ -6,9 +6,13 @@ import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UniverseRepositoryTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/universe/api/UniverseControllerTest.java
+++ b/src/test/java/finance/project/api/universe/api/UniverseControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.core.Is.is;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UniverseController.class)
+@ActiveProfiles("test")
 class UniverseControllerTest {
 
     @Autowired

--- a/src/test/java/finance/project/api/universe/service/UniverseServiceTest.java
+++ b/src/test/java/finance/project/api/universe/service/UniverseServiceTest.java
@@ -195,8 +195,8 @@ class UniverseServiceTest {
                 )
         ));
         List<CsvUniverseSymbol> csvSymbols = List.of(
-                new CsvUniverseSymbol("AAPL", "Apple Inc", "NASDAQ", "USD", "EQUITY", "IBKR"),
-                new CsvUniverseSymbol("msft", "Microsoft", "", "", "", "")
+                new CsvUniverseSymbol("AAPL", "Apple Inc", "NASDAQ", "USD", "EQUITY", "IBKR", "EQUITY", ""),
+                new CsvUniverseSymbol("msft", "Microsoft", "", "", "", "", "", "")
         );
         when(csvUniverseLoader.loadUniverseSymbols("CSV_UNIVERSE")).thenReturn(csvSymbols);
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=YEAR;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.test.database.replace=none
+delta.base-uri=file:///tmp/delta


### PR DESCRIPTION
### Motivation

- Fix multiple test failures caused by missing test profile activation, H2 dialect/SQL differences and a non-central IBKR protobuf dependency.  
- Ensure validation errors from MVC endpoints are returned in a stable JSON shape so slice tests can assert on them.  
- Make data-import job lifecycle updates deterministic (progress/message/status) so runner tests can reliably assert outcomes.  
- Normalize DeltaLake path sanitization for predictable test behavior.

### Description

- Add a local install script `scripts/install-ibkr-jars.sh` and include `src/test/resources/application-test.properties` to configure an H2 in-memory DB and test properties (including `delta.base-uri`).  
- Activate the `test` Spring profile for test slices by adding `@ActiveProfiles("test")` to many tests and set `spring.test.database.replace=none` for JPA slices.  
- Add a `ValidationErrorHandler` (`@RestControllerAdvice`) to render `MethodArgumentNotValidException` as JSON `{ "errors": [...] }`, and update SSE test helpers and `DeltaLakeConfig` sanitization to be test-friendly.  
- Align data-import behavior: refactor `DataImportJobRunner` to centralize running/transition logic (`transitionToRunning`, `markSuccess`, `markFailure`) and update `Performance` entity field name and `PerformanceService` usage to avoid schema/name mismatches; remove explicit `@EnableJpaRepositories` from `Application` so auto-configuration/repository scanning is consistent.  

### Testing

- Executed the install script `scripts/install-ibkr-jars.sh` to install the IBKR protobuf jar to the local Maven repo — this completed successfully.  
- Ran the full test suite with `mvn test` (automated) — the run completed but tests are still failing: `Tests run: 102, Failures: 9, Errors: 13`.  
- Many controller/unit slices and universe-related tests now run under the `test` profile and several JPA/test-slice fixes pass locally (see CI/test logs), while remaining failures are concentrated in a few data-import and integration scenarios.  
- Continued iterative runs were performed during development to zero-in on remaining failures (logs recorded during `mvn test` runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950824bfb748323899bace3fb6f7103)