### PR TITLE
Run JPA tests on MySQL Testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mysql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- JavaFX -->
 		<!-- JavaFX Modules -->

--- a/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionTest.java
+++ b/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import finance.project.api.entities.Candle;
 import finance.project.api.entities.Symbol;
 import finance.project.api.repositories.projections.CandleAvailabilityProjection;
+import finance.project.api.support.AbstractMySqlIntegrationTest;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,7 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class CandleAvailabilityProjectionTest {
+class CandleAvailabilityProjectionTest extends AbstractMySqlIntegrationTest {
 
     @Autowired
     private CandleRepository candleRepository;

--- a/src/test/java/finance/project/api/support/AbstractMySqlIntegrationTest.java
+++ b/src/test/java/finance/project/api/support/AbstractMySqlIntegrationTest.java
@@ -1,0 +1,25 @@
+package finance.project.api.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class AbstractMySqlIntegrationTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.4")
+            .withDatabaseName("finance_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void registerMySqlProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.MySQLDialect");
+    }
+}

--- a/src/test/java/finance/project/api/universe/UniverseRepositoryTest.java
+++ b/src/test/java/finance/project/api/universe/UniverseRepositoryTest.java
@@ -2,6 +2,7 @@ package finance.project.api.universe;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import finance.project.api.support.AbstractMySqlIntegrationTest;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class UniverseRepositoryTest {
+class UniverseRepositoryTest extends AbstractMySqlIntegrationTest {
 
     @Autowired
     private UniverseRepository universeRepository;

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,8 +1,3 @@
-spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;NON_KEYWORDS=YEAR;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.test.database.replace=none


### PR DESCRIPTION
### Motivation
- Ensure `@DataJpaTest` runs against a real MySQL instance using Testcontainers to better match production behaviour.
- Avoid H2-specific configuration from silently overriding datasource settings during JPA tests.
- Provide a reusable base test class to centralize Testcontainers setup and dynamic property registration.

### Description
- Added Testcontainers dependencies `org.testcontainers:mysql` and `org.testcontainers:junit-jupiter` to `pom.xml` for test scope.
- Introduced `AbstractMySqlIntegrationTest` (`src/test/java/finance/project/api/support/AbstractMySqlIntegrationTest.java`) that starts a `MySQLContainer` (`mysql:8.4`) and registers datasource properties via `@DynamicPropertySource` including `spring.jpa.database-platform` set to MySQL dialect.
- Updated `CandleAvailabilityProjectionTest` and `UniverseRepositoryTest` to extend `AbstractMySqlIntegrationTest` so they use the container-backed datasource.
- Removed H2-specific datasource entries from `src/test/resources/application-test.properties` so Testcontainers-provided properties are not clobbered.

### Testing
- No automated tests were executed as part of this change.
- The change includes only test-scoped dependencies and test class updates; run `mvn -DskipTests=false test` locally or in CI to validate `@DataJpaTest` with Testcontainers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69509d6c45148323a196f733e78a6902)