### PR TITLE
Add MySQL integration test base and strengthen DataImportJob integration test

### DIFF
--- a/src/test/java/finance/project/api/AbstractMySqlIntegrationTest.java
+++ b/src/test/java/finance/project/api/AbstractMySqlIntegrationTest.java
@@ -1,0 +1,7 @@
+package finance.project.api;
+
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+public abstract class AbstractMySqlIntegrationTest {
+}

--- a/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerIntegrationTest.java
+++ b/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package finance.project.api.dataimport.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import finance.project.api.AbstractMySqlIntegrationTest;
 import finance.project.api.dataimport.DataImportJob;
 import finance.project.api.dataimport.DataImportJobRepository;
 import finance.project.api.dataimport.DataImportJobRunner;
@@ -14,7 +15,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -29,8 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
-class DataImportJobControllerIntegrationTest {
+class DataImportJobControllerIntegrationTest extends AbstractMySqlIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -78,7 +77,11 @@ class DataImportJobControllerIntegrationTest {
         JsonNode payload = objectMapper.readTree(result.getResponse().getContentAsString());
         String jobId = payload.get("id").asText();
 
-        assertThat(dataImportJobRepository.findById(jobId)).isPresent();
+        DataImportJob persistedJob = dataImportJobRepository.findById(jobId).orElseThrow();
+        assertThat(persistedJob.getBroker()).isEqualTo("IBKR");
+        assertThat(persistedJob.getSymbol()).isEqualTo("AAPL");
+        assertThat(persistedJob.getTimeframe()).isEqualTo("1d");
+        assertThat(persistedJob.getStatus()).isEqualTo(DataImportJob.Status.PENDING);
         verify(dataImportJobRunner).runJobAsync(jobId);
     }
 


### PR DESCRIPTION
### Motivation

- Provide a single test base to enable MySQL-compatible integration tests using the `test` profile.  
- Ensure critical endpoint `/api/data-import/jobs` is validated against real persistence rather than only response payloads.  
- Improve confidence that created `DataImportJob` entities are actually persisted with expected fields.

### Description

- Add `src/test/java/finance/project/api/AbstractMySqlIntegrationTest.java` with `@ActiveProfiles("test")` to act as a base for integration tests.  
- Update `DataImportJobControllerIntegrationTest` to extend `AbstractMySqlIntegrationTest` and remove the duplicate profile annotation.  
- Enhance the create-job test to load the persisted `DataImportJob` from `DataImportJobRepository` and assert `broker`, `symbol`, `timeframe`, and `status` values.  
- Keep `DataImportJobRunner` mocked and repository cleanup in place to isolate the persistence verification.

### Testing

- The integration test file `DataImportJobControllerIntegrationTest` was modified to include additional persistence assertions.  
- No automated test suite was executed as part of this change (no test results to report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69509d718bc48323960a12c684c274b4)