### PR TITLE
Add deterministic TA4J strategy tests and re-enable FilterRuleAdapterTest

### DIFF
--- a/src/test/java/finance/project/api/filters/ta4j/FilterRuleAdapterTest.java
+++ b/src/test/java/finance/project/api/filters/ta4j/FilterRuleAdapterTest.java
@@ -1,11 +1,16 @@
 package finance.project.api.filters.ta4j;
 
 import finance.project.api.filters.Filter;
+import finance.project.api.model.CandleDTO;
+import finance.project.api.model.SymbolDTO;
 import finance.project.api.model.TradeRequestDTO;
 import finance.project.api.model.TradeSignalDTO;
-import finance.project.api.services.CandleCacheManager;
 import org.junit.jupiter.api.Test;
 import org.ta4j.core.BaseTradingRecord;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,6 +25,10 @@ public class FilterRuleAdapterTest {
             public int evaluate(TradeRequestDTO t, finance.project.api.entities.Symbol s, String tf, int p) { return 1; }
             @Override
             public int evaluate(TradeRequestDTO t, String s, String tf, int p) { return 1; }
+            @Override
+            public int evaluate(TradeRequestDTO tradeRequest, List<CandleDTO> candles) {
+                return candles.size() == 10 ? 1 : 0;
+            }
         };
         TradeRequestDTO req = new TradeRequestDTO(TradeSignalDTO.builder()
                 .tradeType(TradeSignalDTO.TradeType.LONG)
@@ -29,14 +38,11 @@ public class FilterRuleAdapterTest {
                 .confidenceScore(0)
                 .symbol("EURUSD")
                 .build());
-        CandleCacheManager cache = new CandleCacheManager() {
-            @Override
-            public java.util.List<finance.project.api.model.CandleDTO> getCandles(String s, String tf, int p) {
-                return java.util.Collections.emptyList();
-            }
-        };
-        //FilterRuleAdapter rule = new FilterRuleAdapter(f, req, "EURUSD", "M1", 10, cache);
-        //assertTrue(rule.isSatisfied(0, new BaseTradingRecord()));
+        List<CandleDTO> candles = buildCandles(15);
+        FilterRuleAdapter rule = new FilterRuleAdapter(f, req, "EURUSD", "1m", 10, candles, 0);
+
+        assertTrue(rule.isSatisfied(12, new BaseTradingRecord()));
+        assertEquals(12, rule.getSatisfiedIndex());
     }
 
     @Test
@@ -48,6 +54,8 @@ public class FilterRuleAdapterTest {
             public int evaluate(TradeRequestDTO t, finance.project.api.entities.Symbol s, String tf, int p) { return 0; }
             @Override
             public int evaluate(TradeRequestDTO t, String s, String tf, int p) { return 0; }
+            @Override
+            public int evaluate(TradeRequestDTO tradeRequest, List<CandleDTO> candles) { return 0; }
         };
         TradeRequestDTO req = new TradeRequestDTO(TradeSignalDTO.builder()
                 .tradeType(TradeSignalDTO.TradeType.LONG)
@@ -57,13 +65,31 @@ public class FilterRuleAdapterTest {
                 .confidenceScore(0)
                 .symbol("EURUSD")
                 .build());
-        CandleCacheManager cache = new CandleCacheManager() {
-            @Override
-            public java.util.List<finance.project.api.model.CandleDTO> getCandles(String s, String tf, int p) {
-                return java.util.Collections.emptyList();
-            }
-        };
-        //FilterRuleAdapter rule = new FilterRuleAdapter(f, req, "EURUSD", "M1", 10, cache);
-        //assertFalse(rule.isSatisfied(0, new BaseTradingRecord()));
+        List<CandleDTO> candles = buildCandles(15);
+        FilterRuleAdapter rule = new FilterRuleAdapter(f, req, "EURUSD", "1m", 10, candles, 0);
+
+        assertFalse(rule.isSatisfied(12, new BaseTradingRecord()));
+        assertEquals(-1, rule.getSatisfiedIndex());
+    }
+
+    private List<CandleDTO> buildCandles(int count) {
+        SymbolDTO symbol = SymbolDTO.builder()
+                .symbol("EURUSD")
+                .name("EURUSD")
+                .market("FX")
+                .build();
+        LocalDateTime start = LocalDateTime.of(2024, 1, 1, 0, 0);
+        return java.util.stream.IntStream.range(0, count)
+                .mapToObj(i -> CandleDTO.builder()
+                        .symbol(symbol)
+                        .timeframe("1m")
+                        .date(start.plusMinutes(i))
+                        .open(BigDecimal.valueOf(1.0 + i))
+                        .high(BigDecimal.valueOf(1.2 + i))
+                        .low(BigDecimal.valueOf(0.8 + i))
+                        .close(BigDecimal.valueOf(1.0 + i))
+                        .volume(BigDecimal.valueOf(100 + i))
+                        .build())
+                .toList();
     }
 }

--- a/src/test/java/finance/project/api/strategies/ta4j/TrendFollowingStrategyTest.java
+++ b/src/test/java/finance/project/api/strategies/ta4j/TrendFollowingStrategyTest.java
@@ -1,0 +1,68 @@
+package finance.project.api.strategies.ta4j;
+
+import finance.project.api.config.StrategyConfig;
+import finance.project.api.model.CandleDTO;
+import finance.project.api.model.SymbolDTO;
+import finance.project.api.services.CandleCacheManager;
+import finance.project.api.services.TA4JService;
+import finance.project.api.services.TradeFilterService;
+import finance.project.api.utils.StrategyResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TrendFollowingStrategyTest {
+
+    @Test
+    void trendFollowingStrategyBuildsDeterministicBuySignal() {
+        List<CandleDTO> candles = buildCandles();
+        StrategyConfig config = new StrategyConfig(new MockEnvironment());
+        config.setEnabledFilters(Collections.emptyList());
+
+        TradeFilterService tradeFilterService = new TradeFilterService(Collections.emptyList(), config, new CandleCacheManager());
+        TrendFollowingStrategy strategy = new TrendFollowingStrategy(new TA4JService(), new CandleCacheManager(), tradeFilterService);
+
+        StrategyResult result = strategy.execute("EURUSD", "1m", 1.0, 2.0, candles, 10);
+
+        assertFalse(result.getSignals().isEmpty(), "Expected at least one BUY signal.");
+        var signal = result.getSignals().getFirst();
+
+        assertEquals(signal.getTradeType(), finance.project.api.model.TradeSignalDTO.TradeType.LONG);
+        assertTrue(signal.getStopLoss() < signal.getEntryPrice(), "Stop loss should be below entry price.");
+        assertTrue(signal.getTakeProfit() > signal.getEntryPrice(), "Take profit should be above entry price.");
+        double rr = (signal.getTakeProfit() - signal.getEntryPrice()) / (signal.getEntryPrice() - signal.getStopLoss());
+        assertEquals(2.0, rr, 1e-6);
+    }
+
+    private List<CandleDTO> buildCandles() {
+        SymbolDTO symbol = SymbolDTO.builder()
+                .symbol("EURUSD")
+                .name("EURUSD")
+                .market("FX")
+                .build();
+        LocalDateTime start = LocalDateTime.of(2024, 1, 1, 0, 0);
+
+        return IntStream.range(0, 120)
+                .mapToObj(i -> {
+                    double close = i < 60 ? 120.0 - i : 60.0 + (i - 60);
+                    return CandleDTO.builder()
+                            .symbol(symbol)
+                            .timeframe("1m")
+                            .date(start.plusMinutes(i))
+                            .open(BigDecimal.valueOf(close - 0.5))
+                            .high(BigDecimal.valueOf(close + 0.5))
+                            .low(BigDecimal.valueOf(close - 1.0))
+                            .close(BigDecimal.valueOf(close))
+                            .volume(BigDecimal.valueOf(100 + i))
+                            .build();
+                })
+                .toList();
+    }
+}

--- a/src/test/java/finance/project/api/strategies/volume/EmaVolumeStrategyTest.java
+++ b/src/test/java/finance/project/api/strategies/volume/EmaVolumeStrategyTest.java
@@ -1,0 +1,66 @@
+package finance.project.api.strategies.volume;
+
+import finance.project.api.model.CandleDTO;
+import finance.project.api.model.SymbolDTO;
+import finance.project.api.services.TA4JService;
+import org.junit.jupiter.api.Test;
+import org.ta4j.core.BarSeries;
+import org.ta4j.core.Strategy;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmaVolumeStrategyTest {
+
+    @Test
+    void emaVolumeStrategyTriggersEntryAndExit() {
+        List<CandleDTO> candles = buildCandles();
+        TA4JService ta4jService = new TA4JService();
+        BarSeries series = ta4jService.convertToTimeSeries(candles, "1m");
+
+        EmaVolumeStrategy strategyBuilder = new EmaVolumeStrategy();
+        Strategy strategy = strategyBuilder.buildStrategy(series);
+
+        int entryIndex = IntStream.range(0, series.getBarCount())
+                .filter(strategy::shouldEnter)
+                .findFirst()
+                .orElse(-1);
+        int exitIndex = IntStream.range(0, series.getBarCount())
+                .filter(i -> i > entryIndex && strategy.shouldExit(i))
+                .findFirst()
+                .orElse(-1);
+
+        assertTrue(entryIndex >= 0, "Expected a BUY signal in the uptrend.");
+        assertTrue(exitIndex > entryIndex, "Expected a SELL signal after the trend reversal.");
+    }
+
+    private List<CandleDTO> buildCandles() {
+        SymbolDTO symbol = SymbolDTO.builder()
+                .symbol("EURUSD")
+                .name("EURUSD")
+                .market("FX")
+                .build();
+        LocalDateTime start = LocalDateTime.of(2024, 1, 1, 0, 0);
+
+        return IntStream.range(0, 120)
+                .mapToObj(i -> {
+                    double close = i < 60 ? 1.0 + i : 61.0 - (i - 60);
+                    double volume = 100 + i;
+                    return CandleDTO.builder()
+                            .symbol(symbol)
+                            .timeframe("1m")
+                            .date(start.plusMinutes(i))
+                            .open(BigDecimal.valueOf(close - 0.2))
+                            .high(BigDecimal.valueOf(close + 0.2))
+                            .low(BigDecimal.valueOf(close - 0.4))
+                            .close(BigDecimal.valueOf(close))
+                            .volume(BigDecimal.valueOf(volume))
+                            .build();
+                })
+                .toList();
+    }
+}


### PR DESCRIPTION
### Motivation

- Add deterministic unit tests for TA4J-based strategies to ensure consistent `BUY/SELL` signals and SL/TP computation.  
- Cover at least two strategies (trend and volume) with fixed candle series to avoid flaky/backtest-dependent results.  
- Re-activate the `FilterRuleAdapterTest` to assert filter-to-rule behavior and `satisfiedIndex` handling.  

### Description

- Added `TrendFollowingStrategyTest` which builds a deterministic `List<CandleDTO>` and exercises `TrendFollowingStrategy.execute(...)` with a `MockEnvironment` `StrategyConfig` and `TradeFilterService`.  
- Added `EmaVolumeStrategyTest` which converts fixed candles via `TA4JService` and asserts an entry then exit using the `EmaVolumeStrategy` TA4J `Strategy`.  
- Re-enabled and updated `FilterRuleAdapterTest` to use concrete `CandleDTO` windows, assert `isSatisfied(...)` results and validate `getSatisfiedIndex()`, and included a `buildCandles(...)` helper.  
- Tests are self-contained and rely on `TA4JService`, `StrategyConfig`, `TradeFilterService` and DTO builders; no production logic was changed.  

### Testing

- New unit tests added: `TrendFollowingStrategyTest`, `EmaVolumeStrategyTest`, and updated `FilterRuleAdapterTest`.  
- Tests are deterministic (fixed candle series and explicit assertions for signals and SL/TP).  
- No automated test suite was executed as part of this change (`mvn test` not run).  
- Files were committed containing the new and updated test classes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69509d746be483238fae59a195f95174)