### PR TITLE
Add @WebMvcTest coverage for controllers' error responses

### DIFF
--- a/src/test/java/finance/project/api/BacktestControllerWebMvcTest.java
+++ b/src/test/java/finance/project/api/BacktestControllerWebMvcTest.java
@@ -1,0 +1,99 @@
+package finance.project.api;
+
+import finance.project.api.controllers.BacktestController;
+import finance.project.api.services.CandleCacheManager;
+import finance.project.api.services.CandleService;
+import finance.project.api.services.PerformanceService;
+import finance.project.api.services.SymbolService;
+import finance.project.api.services.TA4JService;
+import finance.project.api.services.TradeCompletedMapper;
+import finance.project.api.services.TradeCompletedService;
+import finance.project.api.services.TradeService;
+import finance.project.api.services.VolumeBasedRolloverService;
+import finance.project.api.strategies.StrategyManager;
+import finance.project.api.strategies.volume.EmaVolumeStrategy;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BacktestController.class)
+@ActiveProfiles("test")
+class BacktestControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TA4JService ta4JService;
+
+    @MockBean
+    private VolumeBasedRolloverService volumeBasedRolloverService;
+
+    @MockBean
+    private EmaVolumeStrategy emaVolumeStrategy;
+
+    @MockBean
+    private SymbolService symbolService;
+
+    @MockBean
+    private CandleService candleService;
+
+    @MockBean
+    private StrategyManager strategyManager;
+
+    @MockBean
+    private PerformanceService performanceService;
+
+    @MockBean
+    private TradeService tradeService;
+
+    @MockBean
+    private TradeCompletedService tradeCompletedService;
+
+    @MockBean
+    private TradeCompletedMapper tradeCompletedMapper;
+
+    @MockBean
+    private CandleCacheManager candleCacheManager;
+
+    @Test
+    void shouldReturnInternalServerErrorWhenStrategyFails() throws Exception {
+        given(strategyManager.runStrategyByName(
+                "TrendFollowing",
+                "EURUSD",
+                "1h",
+                1000,
+                null,
+                null,
+                null,
+                null,
+                java.time.LocalDateTime.parse("2024-01-01T00:00:00"),
+                java.time.LocalDateTime.parse("2024-01-02T00:00:00")
+        )).willThrow(new RuntimeException("Backtest failure"));
+
+        mockMvc.perform(get("/run-strategy-by-name")
+                        .param("strategyName", "TrendFollowing")
+                        .param("symbol", "EURUSD")
+                        .param("timeframe", "1h")
+                        .param("startDate", "2024-01-01T00:00:00")
+                        .param("endDate", "2024-01-02T00:00:00")
+                        .param("period", "1000")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.error").value("Internal Server Error"))
+                .andExpect(jsonPath("$.message").value("Backtest failure"))
+                .andExpect(jsonPath("$.path").value("/run-strategy-by-name"));
+    }
+}

--- a/src/test/java/finance/project/api/CandleControllerWebMvcTest.java
+++ b/src/test/java/finance/project/api/CandleControllerWebMvcTest.java
@@ -1,0 +1,84 @@
+package finance.project.api;
+
+import finance.project.api.controllers.CandleController;
+import finance.project.api.services.BinanceService;
+import finance.project.api.services.CandleAggregationService;
+import finance.project.api.services.CandleService;
+import finance.project.api.services.CurrencyLayerService;
+import finance.project.api.services.DeltaLakeCandleReader;
+import finance.project.api.services.MarketstackService;
+import finance.project.api.services.SymbolService;
+import finance.project.api.services.TradeCompletedMapper;
+import finance.project.api.services.TradeCompletedService;
+import finance.project.api.services.VolumeBasedRolloverService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@WebMvcTest(CandleController.class)
+@ActiveProfiles("test")
+class CandleControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CandleService candleService;
+
+    @MockBean
+    private MarketstackService marketstackService;
+
+    @MockBean
+    private CurrencyLayerService currencyLayerService;
+
+    @MockBean
+    private CandleAggregationService candleAggregationService;
+
+    @MockBean
+    private VolumeBasedRolloverService volumeBasedRolloverService;
+
+    @MockBean
+    private TradeCompletedService tradeCompletedService;
+
+    @MockBean
+    private TradeCompletedMapper tradeCompletedMapper;
+
+    @MockBean
+    private DeltaLakeCandleReader deltaLakeCandleReader;
+
+    @MockBean
+    private BinanceService binanceService;
+
+    @MockBean
+    private SymbolService symbolService;
+
+    @Test
+    void shouldReturnNotFoundWhenTradeIsMissing() throws Exception {
+        given(tradeCompletedService.getTradeById(1L)).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/finance/charts/from-trade")
+                        .param("tradeId", "1")
+                        .param("timeframe", "5min")
+                        .param("symbol", "EURUSD")
+                        .param("comparedSymbol", "USDJPY")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("Trade not found"))
+                .andExpect(jsonPath("$.path").value("/api/finance/charts/from-trade"));
+    }
+}

--- a/src/test/java/finance/project/api/SymbolControllerWebMvcTest.java
+++ b/src/test/java/finance/project/api/SymbolControllerWebMvcTest.java
@@ -1,0 +1,66 @@
+package finance.project.api;
+
+import finance.project.api.config.ValidationErrorHandler;
+import finance.project.api.controllers.SymbolController;
+import finance.project.api.services.SymbolService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SymbolController.class)
+@Import(ValidationErrorHandler.class)
+@ActiveProfiles("test")
+class SymbolControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SymbolService symbolService;
+
+    @Test
+    void shouldReturnBadRequestWithValidationErrors() throws Exception {
+        mockMvc.perform(post("/api/finance/symbols")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.errors").isArray())
+                .andExpect(jsonPath("$.errors[*].field", containsInAnyOrder("symbol", "name", "market")))
+                .andExpect(jsonPath("$.errors[*].defaultMessage", everyItem(is("must not be null"))));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenSymbolMissing() throws Exception {
+        UUID symbolId = UUID.randomUUID();
+        given(symbolService.getSymbolById(symbolId)).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/finance/symbols/{symbolId}", symbolId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("Value Not Found"))
+                .andExpect(jsonPath("$.path").value("/api/finance/symbols/" + symbolId));
+    }
+}


### PR DESCRIPTION
### Motivation

- Add focused `@WebMvcTest` coverage for critical controllers to lock the HTTP error contract for clients. 
- Verify JSON error payload shape for common failure scenarios (400/404/500) so the API contract stays stable. 
- Ensure global validation exception handler is covered to assert validation error payload structure. 

### Description

- Added `CandleControllerWebMvcTest` which asserts a missing trade returns `404` JSON with `status`, `error`, `message`, and `path` fields.
- Added `BacktestControllerWebMvcTest` which simulates a strategy failure and asserts a `500` JSON payload contains `status`, `error`, `message`, and `path`.
- Added `SymbolControllerWebMvcTest` that imports `ValidationErrorHandler` and asserts both `400` validation error payload (`errors` array with `field` and `defaultMessage`) and `404` NotFound payload (`Value Not Found`).
- Small import/refactor adjustments in test files to align mocked service types and removed unused `ObjectMapper` injection.

### Testing

- Created and committed three new test classes: `CandleControllerWebMvcTest`, `BacktestControllerWebMvcTest`, and `SymbolControllerWebMvcTest` (all `@WebMvcTest`).
- Ran `./mvnw -q test` to execute the test suite, which did not complete due to a missing artifact dependency. 
- The Maven run failed with an unresolved dependency `com.ib:tws-api-proto:jar:10.40`, so the new tests were not executed to completion.
- No other automated test failures were observed before the dependency resolution error prevented full test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69509d774a2883239f716137529c4d3b)