### PR TITLE
Add OKX and Bybit fallback providers for crypto historical imports

### DIFF
--- a/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportJobRunner.java
@@ -22,6 +22,8 @@ public class DataImportJobRunner {
 
     private final DataImportJobRepository jobRepository;
     private final BinanceHistoricalService binanceHistoricalService;
+    private final OkxHistoricalService okxHistoricalService;
+    private final BybitHistoricalService bybitHistoricalService;
     private final MexcHistoricalService mexcHistoricalService;
     private final IbkrImportService ibkrImportService;
     private final DatabentoCsvImportService databentoCsvImportService;
@@ -30,6 +32,8 @@ public class DataImportJobRunner {
 
     public DataImportJobRunner(DataImportJobRepository jobRepository,
                                BinanceHistoricalService binanceHistoricalService,
+                               OkxHistoricalService okxHistoricalService,
+                               BybitHistoricalService bybitHistoricalService,
                                MexcHistoricalService mexcHistoricalService,
                                IbkrImportService ibkrImportService,
                                DatabentoCsvImportService databentoCsvImportService,
@@ -37,6 +41,8 @@ public class DataImportJobRunner {
                                BitgetHistoricalService bitgetHistoricalService) {
         this.jobRepository = jobRepository;
         this.binanceHistoricalService = binanceHistoricalService;
+        this.okxHistoricalService = okxHistoricalService;
+        this.bybitHistoricalService = bybitHistoricalService;
         this.mexcHistoricalService = mexcHistoricalService;
         this.ibkrImportService = ibkrImportService;
         this.databentoCsvImportService = databentoCsvImportService;
@@ -131,9 +137,35 @@ public class DataImportJobRunner {
         boolean ok = binanceHistoricalService.fetchAndSave(job, start, end);
         if (ok) {return true;}
 
-        log.info("[DataImport] Binance returned no data for job {}. Falling back to Bitget.", job.getId());
+        log.info("[DataImport] Binance returned no data for job {}. Falling back to OKX.", job.getId());
 
-        // 2) Fallback Bitget
+        // 2) Fallback OKX
+        job.setBroker("OKX");
+        job.setUpdatedAt(Instant.now());
+        jobRepository.save(job);
+
+        ok = okxHistoricalService.fetchAndSave(job, start, end);
+        if (ok) {
+            log.info("[DataImport] Job {} successfully imported via OKX", job.getId());
+            return true;
+        }
+
+        log.info("[DataImport] OKX also returned no data for job {}. Falling back to Bybit.", job.getId());
+
+        // 3) Fallback Bybit
+        job.setBroker("BYBIT");
+        job.setUpdatedAt(Instant.now());
+        jobRepository.save(job);
+
+        ok = bybitHistoricalService.fetchAndSave(job, start, end);
+        if (ok) {
+            log.info("[DataImport] Job {} successfully imported via Bybit", job.getId());
+            return true;
+        }
+
+        log.info("[DataImport] Bybit also returned no data for job {}. Falling back to Bitget.", job.getId());
+
+        // 4) Fallback Bitget
         job.setBroker("BITGET");
         job.setUpdatedAt(Instant.now());
         jobRepository.save(job);
@@ -146,7 +178,7 @@ public class DataImportJobRunner {
 
         log.info("[DataImport] Bitget also returned no data for job {}. Falling back to MEXC.", job.getId());
 
-        // 3) Fallback MEXC
+        // 5) Fallback MEXC
         job.setBroker("MEXC");
         job.setUpdatedAt(Instant.now());
         jobRepository.save(job);
@@ -157,7 +189,7 @@ public class DataImportJobRunner {
             return true;
         }
 
-        log.warn("[DataImport] No crypto provider (Binance/Bitget/MEXC) could supply data for job {}", job.getId());
+        log.warn("[DataImport] No crypto provider (Binance/OKX/Bybit/Bitget/MEXC) could supply data for job {}", job.getId());
         return false;
     }
 
@@ -170,6 +202,8 @@ public class DataImportJobRunner {
 
         return switch (broker) {
             case "BINANCE" -> invokeCryptoWithFallback(job, start, end);
+            case "OKX" -> okxHistoricalService.fetchAndSave(job, start, end);
+            case "BYBIT" -> bybitHistoricalService.fetchAndSave(job, start, end);
             case "MEXC" -> mexcHistoricalService.fetchAndSave(job, start, end);
             case "BITGET" -> bitgetHistoricalService.fetchAndSave(job, start, end);
             case "IBKR" -> {

--- a/src/main/java/finance/project/api/dataimport/ingestion/BybitHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/BybitHistoricalService.java
@@ -1,0 +1,85 @@
+package finance.project.api.dataimport.ingestion;
+
+import finance.project.api.dataimport.DataImportJob;
+import finance.project.api.dataimport.infrastructure.DeltaLakeExporter;
+import finance.project.api.entities.Candle;
+import finance.project.api.enums.MarketType;
+import finance.project.api.model.CandleDTO;
+import finance.project.api.services.BybitService;
+import finance.project.api.services.CandleAggregationService;
+import finance.project.api.services.CandleService;
+import finance.project.api.utils.TimeframeUtils;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BybitHistoricalService {
+
+    private final BybitService bybitService;
+    private final CandleService candleService;
+    private final CandleAggregationService candleAggregationService;
+    private final DeltaLakeExporter deltaLakeExporter;
+
+    public boolean fetchAndSave(DataImportJob job, Instant start, Instant end) {
+        String symbol = job.getSymbol();
+        String timeframe = job.getTimeframe();
+        LocalDateTime startUtc = LocalDateTime.ofInstant(start, ZoneOffset.UTC);
+        LocalDateTime endUtc = LocalDateTime.ofInstant(end, ZoneOffset.UTC);
+        log.info("[Bybit] Import {} {} from {} to {}", symbol, timeframe, startUtc, endUtc);
+
+        List<CandleDTO> candles;
+        try {
+            candles = bybitService.getHistoricalCandlesInRange(symbol, timeframe, startUtc, endUtc);
+        } catch (Exception e) {
+            log.warn("[Bybit] Error fetching candles for {} {}: {}", symbol, timeframe, e.getMessage());
+            return false;
+        }
+
+        if (candles == null || candles.isEmpty()) {
+            log.warn("[Bybit] No candles returned for {} {} between {} and {}", symbol, timeframe, startUtc, endUtc);
+            return false;
+        }
+
+        candleService.saveCandlesToDatabase(candles, symbol, timeframe);
+        deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, timeframe));
+
+        try {
+            List<CandleDTO> aggregated =
+                    candleAggregationService.aggregateCandles(candles, timeframe, MarketType.CRYPTO);
+            if (!aggregated.isEmpty()) {
+                candleService.saveCandlesToDatabase(aggregated, symbol, timeframe);
+            }
+        } catch (IllegalArgumentException ex) {
+            log.warn("[Bybit] Timeframe {} not supported for aggregation: {}", timeframe, ex.getMessage());
+        }
+
+        return true;
+    }
+
+    private List<Candle> mapForDelta(List<CandleDTO> candles, String timeframe) {
+        List<Candle> entities = new java.util.ArrayList<>(candles.size());
+        String normalized = TimeframeUtils.mapToCustomTimeframe(timeframe);
+        for (CandleDTO dto : candles) {
+            if (dto == null) {
+                continue;
+            }
+            Candle candle = new Candle();
+            candle.setTimeframe(normalized);
+            candle.setDate(dto.getDate());
+            candle.setOpen(dto.getOpen());
+            candle.setClose(dto.getClose());
+            candle.setHigh(dto.getHigh());
+            candle.setLow(dto.getLow());
+            candle.setVolume(dto.getVolume());
+            entities.add(candle);
+        }
+        return entities;
+    }
+}

--- a/src/main/java/finance/project/api/dataimport/ingestion/OkxHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/OkxHistoricalService.java
@@ -1,0 +1,85 @@
+package finance.project.api.dataimport.ingestion;
+
+import finance.project.api.dataimport.DataImportJob;
+import finance.project.api.dataimport.infrastructure.DeltaLakeExporter;
+import finance.project.api.entities.Candle;
+import finance.project.api.enums.MarketType;
+import finance.project.api.model.CandleDTO;
+import finance.project.api.services.CandleAggregationService;
+import finance.project.api.services.CandleService;
+import finance.project.api.services.OkxService;
+import finance.project.api.utils.TimeframeUtils;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OkxHistoricalService {
+
+    private final OkxService okxService;
+    private final CandleService candleService;
+    private final CandleAggregationService candleAggregationService;
+    private final DeltaLakeExporter deltaLakeExporter;
+
+    public boolean fetchAndSave(DataImportJob job, Instant start, Instant end) {
+        String symbol = job.getSymbol();
+        String timeframe = job.getTimeframe();
+        LocalDateTime startUtc = LocalDateTime.ofInstant(start, ZoneOffset.UTC);
+        LocalDateTime endUtc = LocalDateTime.ofInstant(end, ZoneOffset.UTC);
+        log.info("[OKX] Import {} {} from {} to {}", symbol, timeframe, startUtc, endUtc);
+
+        List<CandleDTO> candles;
+        try {
+            candles = okxService.getHistoricalCandlesInRange(symbol, timeframe, startUtc, endUtc);
+        } catch (Exception e) {
+            log.warn("[OKX] Error fetching candles for {} {}: {}", symbol, timeframe, e.getMessage());
+            return false;
+        }
+
+        if (candles == null || candles.isEmpty()) {
+            log.warn("[OKX] No candles returned for {} {} between {} and {}", symbol, timeframe, startUtc, endUtc);
+            return false;
+        }
+
+        candleService.saveCandlesToDatabase(candles, symbol, timeframe);
+        deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, timeframe));
+
+        try {
+            List<CandleDTO> aggregated =
+                    candleAggregationService.aggregateCandles(candles, timeframe, MarketType.CRYPTO);
+            if (!aggregated.isEmpty()) {
+                candleService.saveCandlesToDatabase(aggregated, symbol, timeframe);
+            }
+        } catch (IllegalArgumentException ex) {
+            log.warn("[OKX] Timeframe {} not supported for aggregation: {}", timeframe, ex.getMessage());
+        }
+
+        return true;
+    }
+
+    private List<Candle> mapForDelta(List<CandleDTO> candles, String timeframe) {
+        List<Candle> entities = new java.util.ArrayList<>(candles.size());
+        String normalized = TimeframeUtils.mapToCustomTimeframe(timeframe);
+        for (CandleDTO dto : candles) {
+            if (dto == null) {
+                continue;
+            }
+            Candle candle = new Candle();
+            candle.setTimeframe(normalized);
+            candle.setDate(dto.getDate());
+            candle.setOpen(dto.getOpen());
+            candle.setClose(dto.getClose());
+            candle.setHigh(dto.getHigh());
+            candle.setLow(dto.getLow());
+            candle.setVolume(dto.getVolume());
+            entities.add(candle);
+        }
+        return entities;
+    }
+}

--- a/src/main/java/finance/project/api/services/BybitService.java
+++ b/src/main/java/finance/project/api/services/BybitService.java
@@ -1,0 +1,189 @@
+package finance.project.api.services;
+
+import finance.project.api.model.CandleDTO;
+import finance.project.api.model.SymbolDTO;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class BybitService {
+
+    private static final String BASE_URL = "https://api.bybit.com";
+
+    private final RestTemplate restTemplate;
+
+    public List<CandleDTO> getHistoricalCandlesInRange(
+            String symbol,
+            String timeframe,
+            LocalDateTime start,
+            LocalDateTime end
+    ) {
+        String interval = mapToBybitInterval(timeframe);
+        if (interval == null) {
+            log.warn("[Bybit] Unsupported timeframe '{}' -> returning empty list", timeframe);
+            return List.of();
+        }
+
+        long startMs = start.toInstant(ZoneOffset.UTC).toEpochMilli();
+        long endMs = end.toInstant(ZoneOffset.UTC).toEpochMilli();
+
+        URI uri = UriComponentsBuilder.fromHttpUrl(BASE_URL + "/v5/market/kline")
+                .queryParam("category", "spot")
+                .queryParam("symbol", symbol.toUpperCase())
+                .queryParam("interval", interval)
+                .queryParam("start", startMs)
+                .queryParam("end", endMs)
+                .queryParam("limit", 1000)
+                .build(true)
+                .toUri();
+
+        log.info("[Bybit] Fetching kline symbol={} interval={} start={} end={}",
+                symbol, interval, start, end);
+
+        try {
+            RequestEntity<Void> req = new RequestEntity<>(HttpMethod.GET, uri);
+            ResponseEntity<BybitResponse> resp = restTemplate.exchange(
+                    req,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            BybitResponse body = resp.getBody();
+            if (body == null || body.result == null || body.result.list == null || body.result.list.isEmpty()) {
+                log.info("[Bybit] No candles returned for {} {}", symbol, timeframe);
+                return List.of();
+            }
+
+            List<CandleDTO> result = new ArrayList<>(body.result.list.size());
+            for (List<String> k : body.result.list) {
+                if (k.size() < 6) {
+                    continue;
+                }
+                long openTimeMs = asLong(k.get(0));
+                Instant ts = Instant.ofEpochMilli(openTimeMs);
+
+                double open = asDouble(k.get(1));
+                double high = asDouble(k.get(2));
+                double low = asDouble(k.get(3));
+                double close = asDouble(k.get(4));
+                double volume = asDouble(k.get(5));
+
+                CandleDTO dto = CandleDTO.builder()
+                        .date(LocalDateTime.ofInstant(ts, ZoneOffset.UTC))
+                        .open(new BigDecimal(open))
+                        .high(new BigDecimal(high))
+                        .low(new BigDecimal(low))
+                        .close(new BigDecimal(close))
+                        .volume(new BigDecimal(volume))
+                        .symbol(SymbolDTO.builder().symbol(symbol).build())
+                        .timeframe(interval)
+                        .build();
+                result.add(dto);
+            }
+
+            return result;
+        } catch (Exception e) {
+            log.warn("[Bybit] Error fetching kline for {} {}: {}", symbol, timeframe, e.getMessage());
+            return List.of();
+        }
+    }
+
+    private String mapToBybitInterval(String timeframe) {
+        if (timeframe == null) {
+            return null;
+        }
+        return switch (timeframe.toLowerCase()) {
+            case "1m", "1min" -> "1";
+            case "3m" -> "3";
+            case "5m" -> "5";
+            case "15m" -> "15";
+            case "30m" -> "30";
+            case "1h", "60m" -> "60";
+            case "2h", "120m" -> "120";
+            case "4h", "240m" -> "240";
+            case "6h", "360m" -> "360";
+            case "12h", "720m" -> "720";
+            case "1d", "daily" -> "D";
+            case "1w", "weekly" -> "W";
+            case "1mo", "monthly" -> "M";
+            default -> null;
+        };
+    }
+
+    private long asLong(Object o) {
+        if (o == null) {
+            return 0L;
+        }
+        if (o instanceof Number n) {
+            return n.longValue();
+        }
+        return Long.parseLong(o.toString());
+    }
+
+    private double asDouble(Object o) {
+        if (o == null) {
+            return 0d;
+        }
+        if (o instanceof Number n) {
+            return n.doubleValue();
+        }
+        return new BigDecimal(o.toString()).doubleValue();
+    }
+
+    private static class BybitResponse {
+        private String retCode;
+        private String retMsg;
+        private BybitResult result;
+
+        public String getRetCode() {
+            return retCode;
+        }
+
+        public void setRetCode(String retCode) {
+            this.retCode = retCode;
+        }
+
+        public String getRetMsg() {
+            return retMsg;
+        }
+
+        public void setRetMsg(String retMsg) {
+            this.retMsg = retMsg;
+        }
+
+        public BybitResult getResult() {
+            return result;
+        }
+
+        public void setResult(BybitResult result) {
+            this.result = result;
+        }
+    }
+
+    private static class BybitResult {
+        private List<List<String>> list;
+
+        public List<List<String>> getList() {
+            return list;
+        }
+
+        public void setList(List<List<String>> list) {
+            this.list = list;
+        }
+    }
+}

--- a/src/main/java/finance/project/api/services/OkxService.java
+++ b/src/main/java/finance/project/api/services/OkxService.java
@@ -1,0 +1,197 @@
+package finance.project.api.services;
+
+import finance.project.api.model.CandleDTO;
+import finance.project.api.model.SymbolDTO;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OkxService {
+
+    private static final String BASE_URL = "https://www.okx.com";
+
+    private final RestTemplate restTemplate;
+
+    public List<CandleDTO> getHistoricalCandlesInRange(
+            String symbol,
+            String timeframe,
+            LocalDateTime start,
+            LocalDateTime end
+    ) {
+        String bar = mapToOkxBar(timeframe);
+        if (bar == null) {
+            log.warn("[OKX] Unsupported timeframe '{}' -> returning empty list", timeframe);
+            return List.of();
+        }
+
+        long startMs = start.toInstant(ZoneOffset.UTC).toEpochMilli();
+        long endMs = end.toInstant(ZoneOffset.UTC).toEpochMilli();
+
+        URI uri = UriComponentsBuilder.fromHttpUrl(BASE_URL + "/api/v5/market/history-candles")
+                .queryParam("instId", normalizeOkxSymbol(symbol))
+                .queryParam("bar", bar)
+                .queryParam("after", String.valueOf(startMs))
+                .queryParam("before", String.valueOf(endMs))
+                .queryParam("limit", "100")
+                .build(true)
+                .toUri();
+
+        log.info("[OKX] Fetching history-candles symbol={} bar={} start={} end={}",
+                symbol, bar, start, end);
+
+        try {
+            RequestEntity<Void> req = new RequestEntity<>(HttpMethod.GET, uri);
+            ResponseEntity<OkxResponse<List<List<String>>>> resp = restTemplate.exchange(
+                    req,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            OkxResponse<List<List<String>>> body = resp.getBody();
+            if (body == null || body.data == null || body.data.isEmpty()) {
+                log.info("[OKX] No candles returned for {} {}", symbol, timeframe);
+                return List.of();
+            }
+
+            List<CandleDTO> result = new ArrayList<>(body.data.size());
+            for (List<String> k : body.data) {
+                if (k.size() < 6) {
+                    continue;
+                }
+                long openTimeMs = asLong(k.get(0));
+                Instant ts = Instant.ofEpochMilli(openTimeMs);
+
+                double open = asDouble(k.get(1));
+                double high = asDouble(k.get(2));
+                double low = asDouble(k.get(3));
+                double close = asDouble(k.get(4));
+                double volume = asDouble(k.get(5));
+
+                CandleDTO dto = CandleDTO.builder()
+                        .date(LocalDateTime.ofInstant(ts, ZoneOffset.UTC))
+                        .open(new BigDecimal(open))
+                        .high(new BigDecimal(high))
+                        .low(new BigDecimal(low))
+                        .close(new BigDecimal(close))
+                        .volume(new BigDecimal(volume))
+                        .symbol(SymbolDTO.builder().symbol(symbol).build())
+                        .timeframe(bar)
+                        .build();
+                result.add(dto);
+            }
+
+            return result;
+        } catch (Exception e) {
+            log.warn("[OKX] Error fetching history-candles for {} {}: {}", symbol, timeframe, e.getMessage());
+            return List.of();
+        }
+    }
+
+    private String normalizeOkxSymbol(String symbol) {
+        if (symbol == null) {
+            return null;
+        }
+        String s = symbol.toUpperCase();
+        if (s.contains("-")) {
+            return s;
+        }
+        if (s.endsWith("USDT")) {
+            return s.substring(0, s.length() - 4) + "-USDT";
+        }
+        if (s.endsWith("USDC")) {
+            return s.substring(0, s.length() - 4) + "-USDC";
+        }
+        if (s.endsWith("USD")) {
+            return s.substring(0, s.length() - 3) + "-USD";
+        }
+        return s;
+    }
+
+    private String mapToOkxBar(String timeframe) {
+        if (timeframe == null) {
+            return null;
+        }
+        return switch (timeframe.toLowerCase()) {
+            case "1m", "1min" -> "1m";
+            case "3m" -> "3m";
+            case "5m" -> "5m";
+            case "10m" -> "10m";
+            case "15m" -> "15m";
+            case "30m" -> "30m";
+            case "1h", "60m" -> "1H";
+            case "2h", "120m" -> "2H";
+            case "4h", "240m" -> "4H";
+            case "6h", "360m" -> "6H";
+            case "12h", "720m" -> "12H";
+            case "1d", "daily" -> "1D";
+            case "1w", "weekly" -> "1W";
+            case "1mo", "monthly" -> "1M";
+            default -> null;
+        };
+    }
+
+    private long asLong(Object o) {
+        if (o == null) {
+            return 0L;
+        }
+        if (o instanceof Number n) {
+            return n.longValue();
+        }
+        return Long.parseLong(o.toString());
+    }
+
+    private double asDouble(Object o) {
+        if (o == null) {
+            return 0d;
+        }
+        if (o instanceof Number n) {
+            return n.doubleValue();
+        }
+        return new BigDecimal(o.toString()).doubleValue();
+    }
+
+    private static class OkxResponse<T> {
+        private String code;
+        private String msg;
+        private T data;
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(String code) {
+            this.code = code;
+        }
+
+        public String getMsg() {
+            return msg;
+        }
+
+        public void setMsg(String msg) {
+            this.msg = msg;
+        }
+
+        public T getData() {
+            return data;
+        }
+
+        public void setData(T data) {
+            this.data = data;
+        }
+    }
+}

--- a/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
+++ b/src/test/java/finance/project/api/dataimport/DataImportJobRunnerTest.java
@@ -8,10 +8,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import finance.project.api.dataimport.ingestion.BinanceHistoricalService;
+import finance.project.api.dataimport.ingestion.BybitHistoricalService;
 import finance.project.api.dataimport.ingestion.CsvImportService;
 import finance.project.api.dataimport.ingestion.DatabentoCsvImportService;
 import finance.project.api.dataimport.ingestion.IbkrImportService;
 import finance.project.api.dataimport.ingestion.MexcHistoricalService;
+import finance.project.api.dataimport.ingestion.OkxHistoricalService;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,12 @@ class DataImportJobRunnerTest {
 
     @Mock
     private BinanceHistoricalService binanceHistoricalService;
+
+    @Mock
+    private OkxHistoricalService okxHistoricalService;
+
+    @Mock
+    private BybitHistoricalService bybitHistoricalService;
 
     @Mock
     private MexcHistoricalService mexcHistoricalService;


### PR DESCRIPTION
### Motivation
- Étendre la résilience de l'import historique crypto en ajoutant d’autres fournisseurs si Binance ne renvoie pas de données.
- Prévoir des adaptateurs dédiés pour OKX et Bybit afin d’homogénéiser la logique d’ingestion des bougies.
- Permettre au runner d’itérer sur un nouvel ordre de fallback sans modifier la logique d’enregistrement des bougies.

### Description
- Ajout des services `OkxService` et `BybitService` et des ingestions `OkxHistoricalService` et `BybitHistoricalService` pour récupérer/mapper des `CandleDTO` depuis OKX et Bybit.
- Mise à jour de `DataImportJobRunner` : injection des nouveaux services, extension du `invokeCryptoWithFallback` pour l’ordre de fallback `BINANCE -> OKX -> BYBIT -> BITGET -> MEXC`, et ajout des cas `OKX` et `BYBIT` dans le `switch` de `invokeBrokerImport`.
- Adaptation du constructeur et des champs de `DataImportJobRunner` pour inclure `OkxHistoricalService` et `BybitHistoricalService`.
- Mise à jour du test unitaire `DataImportJobRunnerTest` pour ajouter des `@Mock` pour `OkxHistoricalService` et `BybitHistoricalService`.

### Testing
- Aucun test automatisé n’a été exécuté dans cette PR (modifications compilées et commitées mais `mvn test` non lancé).
- Le test unitaire modifié est `DataImportJobRunnerTest` et il a été adapté pour injecter les nouveaux mocks.
- Aucune suite CI n’a été déclenchée dans le transcript fourni.
- Il est recommandé d’exécuter `mvn -DskipTests=false test` ou de lancer la CI pour valider l’intégration et ajuster les mappings temporels si nécessaire.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544a01a75883239a86d64e0176cd45)