### PR TITLE
Add MySQL DataJpa tests and comparison date-range query

### DIFF
--- a/src/main/java/finance/project/api/repositories/ComparisonRepository.java
+++ b/src/main/java/finance/project/api/repositories/ComparisonRepository.java
@@ -2,10 +2,27 @@ package finance.project.api.repositories;
 
 import finance.project.api.entities.Comparison;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface ComparisonRepository extends JpaRepository<Comparison, UUID> {
+    @Query("""
+            SELECT c
+            FROM Comparison c
+            WHERE c.symbol1.id = :symbolId
+              AND c.startDate >= :startDate
+              AND c.endDate <= :endDate
+            ORDER BY c.startDate ASC
+            """)
+    List<Comparison> findBySymbol1IdAndDateRange(
+            @Param("symbolId") UUID symbolId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/test/java/finance/project/api/repositories/CandleRepositoryTest.java
+++ b/src/test/java/finance/project/api/repositories/CandleRepositoryTest.java
@@ -1,0 +1,94 @@
+package finance.project.api.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import finance.project.api.entities.Candle;
+import finance.project.api.entities.Symbol;
+import finance.project.api.repositories.projections.CandleAvailabilityProjection;
+import finance.project.api.support.AbstractMySqlIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CandleRepositoryTest extends AbstractMySqlIntegrationTest {
+
+    @Autowired
+    private CandleRepository candleRepository;
+
+    @Autowired
+    private SymbolRepository symbolRepository;
+
+    @Test
+    void findAvailabilitySummaryAggregatesCountsAndRanges() {
+        Symbol apple = symbolRepository.save(Symbol.builder()
+                .symbol("AAPL")
+                .name("Apple Inc.")
+                .market("NASDAQ")
+                .build());
+
+        Symbol microsoft = symbolRepository.save(Symbol.builder()
+                .symbol("MSFT")
+                .name("Microsoft")
+                .market("NASDAQ")
+                .build());
+
+        candleRepository.saveAll(List.of(
+                Candle.builder()
+                        .symbol(apple)
+                        .timeframe("1D")
+                        .date(LocalDateTime.of(2024, 1, 1, 0, 0))
+                        .open(BigDecimal.ONE)
+                        .close(BigDecimal.ONE)
+                        .high(BigDecimal.ONE)
+                        .low(BigDecimal.ONE)
+                        .build(),
+                Candle.builder()
+                        .symbol(apple)
+                        .timeframe("1D")
+                        .date(LocalDateTime.of(2024, 1, 3, 0, 0))
+                        .open(BigDecimal.ONE)
+                        .close(BigDecimal.ONE)
+                        .high(BigDecimal.ONE)
+                        .low(BigDecimal.ONE)
+                        .build(),
+                Candle.builder()
+                        .symbol(microsoft)
+                        .timeframe("1H")
+                        .date(LocalDateTime.of(2024, 2, 1, 9, 0))
+                        .open(BigDecimal.ONE)
+                        .close(BigDecimal.ONE)
+                        .high(BigDecimal.ONE)
+                        .low(BigDecimal.ONE)
+                        .build()
+        ));
+
+        List<CandleAvailabilityProjection> availability = candleRepository.findAvailabilitySummary();
+        Map<String, CandleAvailabilityProjection> availabilityByKey = availability.stream()
+                .collect(Collectors.toMap(
+                        projection -> projection.getSymbol() + ":" + projection.getTimeframe(),
+                        projection -> projection
+                ));
+
+        CandleAvailabilityProjection appleDaily = availabilityByKey.get("AAPL:1D");
+        assertThat(appleDaily.getCount()).isEqualTo(2L);
+        assertThat(appleDaily.getStart()).isEqualTo(LocalDateTime.of(2024, 1, 1, 0, 0));
+        assertThat(appleDaily.getEnd()).isEqualTo(LocalDateTime.of(2024, 1, 3, 0, 0));
+        assertThat(appleDaily.getMarketType()).isEqualTo("NASDAQ");
+
+        CandleAvailabilityProjection microsoftHourly = availabilityByKey.get("MSFT:1H");
+        assertThat(microsoftHourly.getCount()).isEqualTo(1L);
+        assertThat(microsoftHourly.getStart()).isEqualTo(LocalDateTime.of(2024, 2, 1, 9, 0));
+        assertThat(microsoftHourly.getEnd()).isEqualTo(LocalDateTime.of(2024, 2, 1, 9, 0));
+        assertThat(microsoftHourly.getMarketType()).isEqualTo("NASDAQ");
+    }
+}

--- a/src/test/java/finance/project/api/repositories/ComparisonRepositoryTest.java
+++ b/src/test/java/finance/project/api/repositories/ComparisonRepositoryTest.java
@@ -2,6 +2,9 @@ package finance.project.api.repositories;
 
 import finance.project.api.entities.Comparison;
 import finance.project.api.entities.Symbol;
+import finance.project.api.support.AbstractMySqlIntegrationTest;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -9,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -17,7 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-public class ComparisonRepositoryTest {
+class ComparisonRepositoryTest extends AbstractMySqlIntegrationTest {
 
     @Autowired
     private ComparisonRepository comparisonRepository;
@@ -26,7 +28,7 @@ public class ComparisonRepositoryTest {
     private SymbolRepository symbolRepository;
 
     @Test
-    public void testSaveComparison() {
+    void testSaveComparison() {
         Symbol symbol1 = symbolRepository.save(Symbol.builder().symbol("AAPL").name("Apple Inc.").market("NASDAQ").build());
         Symbol symbol2 = symbolRepository.save(Symbol.builder().symbol("GOOGL").name("Google LLC").market("NASDAQ").build());
 
@@ -45,5 +47,65 @@ public class ComparisonRepositoryTest {
         assertThat(savedComparison).isPresent();
         assertThat(savedComparison.get().getSymbol1().getSymbol()).isEqualTo("AAPL");
         assertThat(savedComparison.get().getPerformance1()).isEqualTo(BigDecimal.valueOf(10.5));
+    }
+
+    @Test
+    void findBySymbol1IdAndDateRangeReturnsOrderedMatches() {
+        Symbol symbol1 = symbolRepository.save(Symbol.builder().symbol("AAPL").name("Apple Inc.").market("NASDAQ").build());
+        Symbol symbol2 = symbolRepository.save(Symbol.builder().symbol("MSFT").name("Microsoft").market("NASDAQ").build());
+
+        Comparison first = Comparison.builder()
+                .symbol1(symbol1)
+                .symbol2(symbol2)
+                .performance1(BigDecimal.valueOf(1.1))
+                .performance2(BigDecimal.valueOf(2.2))
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 1, 15))
+                .build();
+
+        Comparison second = Comparison.builder()
+                .symbol1(symbol1)
+                .symbol2(symbol2)
+                .performance1(BigDecimal.valueOf(3.3))
+                .performance2(BigDecimal.valueOf(4.4))
+                .startDate(LocalDate.of(2024, 2, 1))
+                .endDate(LocalDate.of(2024, 2, 15))
+                .build();
+
+        comparisonRepository.save(first);
+        comparisonRepository.save(second);
+
+        List<Comparison> results = comparisonRepository.findBySymbol1IdAndDateRange(
+                symbol1.getId(),
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 3, 1)
+        );
+
+        assertThat(results.size()).isEqualTo(2);
+        assertThat(results.get(0).getStartDate()).isEqualTo(LocalDate.of(2024, 1, 1));
+        assertThat(results.get(1).getStartDate()).isEqualTo(LocalDate.of(2024, 2, 1));
+    }
+
+    @Test
+    void findBySymbol1IdAndDateRangeReturnsEmptyWhenNoData() {
+        Symbol symbol1 = symbolRepository.save(Symbol.builder().symbol("AAPL").name("Apple Inc.").market("NASDAQ").build());
+        Symbol symbol2 = symbolRepository.save(Symbol.builder().symbol("MSFT").name("Microsoft").market("NASDAQ").build());
+
+        comparisonRepository.save(Comparison.builder()
+                .symbol1(symbol1)
+                .symbol2(symbol2)
+                .performance1(BigDecimal.valueOf(1.1))
+                .performance2(BigDecimal.valueOf(2.2))
+                .startDate(LocalDate.of(2024, 1, 1))
+                .endDate(LocalDate.of(2024, 1, 15))
+                .build());
+
+        List<Comparison> results = comparisonRepository.findBySymbol1IdAndDateRange(
+                symbol1.getId(),
+                LocalDate.of(2024, 2, 1),
+                LocalDate.of(2024, 3, 1)
+        );
+
+        assertThat(results).isEqualTo(List.of());
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure custom repository queries and projections are validated against MySQL Testcontainers rather than H2 to avoid dialect/behavior drift.  
- Cover critical repository behaviors: `CandleRepository` availability aggregation and `ComparisonRepository` date-range filtering.  
- Verify exact counts, date ranges, group-by behavior and ordering for real MySQL.  
- Add a regression test for the “no data” case to guarantee stable empty results.

### Description

- Add a custom JPQL query `findBySymbol1IdAndDateRange` to `ComparisonRepository` that filters by `symbol1.id` and date range and orders by `startDate`.  
- Extend `ComparisonRepositoryTest` to use `AbstractMySqlIntegrationTest` and add two MySQL-backed tests: one asserting ordered matches and one asserting an empty result when no rows match.  
- Add `CandleRepositoryTest` (MySQL-backed `@DataJpaTest`) that inserts sample `Candle` rows and verifies `findAvailabilitySummary` via the `CandleAvailabilityProjection` for counts, min/max dates and market grouping.  
- Tests and test classes are configured to use real MySQL via `AbstractMySqlIntegrationTest` (Testcontainers) and `@AutoConfigureTestDatabase(replace = NONE)`.

### Testing

- Ran the MVN command `./mvnw -q -Dtest=CandleRepositoryTest,ComparisonRepositoryTest test` to execute the new tests under Testcontainers.  
- Test execution was interrupted because Testcontainers/MySQL startup did not complete in the session, so automated test results are inconclusive.  
- The project compiles and the new tests were committed locally after adding `CandleRepositoryTest` and updating `ComparisonRepositoryTest`.  
- Further CI or local re-run (with Testcontainers allowed to start) is required to validate passing status on MySQL.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e53c23bc83239b8173f23bf24b2a)