### PR TITLE
Add Jackson ISO-8601 annotations to DTOs and ObjectMapper round-trip tests

### DIFF
--- a/src/main/java/finance/project/api/model/CandleDTO.java
+++ b/src/main/java/finance/project/api/model/CandleDTO.java
@@ -1,14 +1,11 @@
 package finance.project.api.model;
 
-
-import finance.project.api.entities.Symbol;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Data;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Builder(toBuilder = true)
 @Data
@@ -17,6 +14,7 @@ public class CandleDTO {
     private String timeframe;
     private SymbolDTO symbol; // Utilisation du DTO au lieu de l'entité
     private String symbolFuture;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private LocalDateTime date;
     private BigDecimal open;
     private BigDecimal close;

--- a/src/main/java/finance/project/api/model/TradeCompletedDTO.java
+++ b/src/main/java/finance/project/api/model/TradeCompletedDTO.java
@@ -1,5 +1,7 @@
 package finance.project.api.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,8 +22,8 @@ public record TradeCompletedDTO(
         BigDecimal quantity,
         Integer cycleId,
         double confidenceScore,
-        LocalDateTime entryTimestamp,
-        LocalDateTime exitTimestamp,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) LocalDateTime entryTimestamp,
+        @JsonFormat(shape = JsonFormat.Shape.STRING) LocalDateTime exitTimestamp,
         String symbol,
         List<IntermediateEntryDTO> intermediateEntries
 ) {

--- a/src/main/java/finance/project/api/model/TradeSignalDTO.java
+++ b/src/main/java/finance/project/api/model/TradeSignalDTO.java
@@ -1,11 +1,15 @@
 package finance.project.api.model;
 
-import lombok.*;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Builder
-@AllArgsConstructor
 @Getter
 @Setter
 public class TradeSignalDTO {
@@ -16,6 +20,7 @@ public class TradeSignalDTO {
     private final double stopLoss;
     private final double takeProfit;
     private final double confidenceScore;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private final LocalDateTime timestamp;
 
     public boolean isSecondEntry() {
@@ -29,6 +34,27 @@ public class TradeSignalDTO {
     }
 
     private final String symbol;
+
+    @JsonCreator
+    public TradeSignalDTO(
+            @JsonProperty("tradeType") TradeType tradeType,
+            @JsonProperty("entryPrice") double entryPrice,
+            @JsonProperty("stopLoss") double stopLoss,
+            @JsonProperty("takeProfit") double takeProfit,
+            @JsonProperty("confidenceScore") double confidenceScore,
+            @JsonProperty("timestamp") LocalDateTime timestamp,
+            @JsonProperty("secondEntry") boolean secondEntry,
+            @JsonProperty("symbol") String symbol
+    ) {
+        this.tradeType = tradeType;
+        this.entryPrice = entryPrice;
+        this.stopLoss = stopLoss;
+        this.takeProfit = takeProfit;
+        this.confidenceScore = confidenceScore;
+        this.timestamp = timestamp;
+        this.secondEntry = secondEntry;
+        this.symbol = symbol;
+    }
 
     public TradeSignalDTO(TradeType tradeType, double entryPrice, double stopLoss, double takeProfit, double confidenceScore, String symbol) {
         this.tradeType = tradeType;

--- a/src/test/java/finance/project/api/model/DtoObjectMapperTest.java
+++ b/src/test/java/finance/project/api/model/DtoObjectMapperTest.java
@@ -1,0 +1,140 @@
+package finance.project.api.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DtoObjectMapperTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Test
+    void tradeSignalDtoRoundTripUsesIsoTimestamp() throws Exception {
+        LocalDateTime timestamp = LocalDateTime.of(2024, 2, 3, 4, 5, 6);
+        TradeSignalDTO dto = TradeSignalDTO.builder()
+                .tradeType(TradeSignalDTO.TradeType.LONG)
+                .entryPrice(101.12)
+                .stopLoss(95.50)
+                .takeProfit(120.75)
+                .confidenceScore(0.92)
+                .timestamp(timestamp)
+                .secondEntry(true)
+                .symbol("AAPL")
+                .build();
+
+        String json = objectMapper.writeValueAsString(dto);
+        JsonNode node = objectMapper.readTree(json);
+
+        assertThat(node.get("timestamp").asText()).isEqualTo("2024-02-03T04:05:06");
+
+        TradeSignalDTO restored = objectMapper.readValue(json, TradeSignalDTO.class);
+
+        assertThat(restored.getTradeType()).isEqualTo(dto.getTradeType());
+        assertThat(restored.getEntryPrice()).isEqualTo(dto.getEntryPrice());
+        assertThat(restored.getStopLoss()).isEqualTo(dto.getStopLoss());
+        assertThat(restored.getTakeProfit()).isEqualTo(dto.getTakeProfit());
+        assertThat(restored.getConfidenceScore()).isEqualTo(dto.getConfidenceScore());
+        assertThat(restored.getTimestamp()).isEqualTo(dto.getTimestamp());
+        assertThat(restored.isSecondEntry()).isEqualTo(dto.isSecondEntry());
+        assertThat(restored.getSymbol()).isEqualTo(dto.getSymbol());
+    }
+
+    @Test
+    void tradeCompletedDtoRoundTripPreservesValues() throws Exception {
+        LocalDateTime entryTimestamp = LocalDateTime.of(2024, 1, 1, 10, 15, 30);
+        LocalDateTime exitTimestamp = LocalDateTime.of(2024, 1, 2, 11, 45, 0);
+        OffsetDateTime entryOffset = OffsetDateTime.parse("2024-01-01T10:00:00+01:00");
+        IntermediateEntryDTO intermediateEntry = new IntermediateEntryDTO(
+                1,
+                entryOffset,
+                0.2,
+                172.42,
+                -30.0,
+                -30.2225,
+                0.2
+        );
+
+        TradeCompletedDTO dto = new TradeCompletedDTO(
+                10L,
+                "Momentum",
+                "run-123",
+                TradeSignalDTO.TradeType.SHORT,
+                "Equity",
+                100.5,
+                98.2,
+                110.75,
+                105.3,
+                4.8,
+                new BigDecimal("1.2345"),
+                new BigDecimal("-2.5000"),
+                new BigDecimal("3.333"),
+                4,
+                0.88,
+                entryTimestamp,
+                exitTimestamp,
+                "AAPL",
+                List.of(intermediateEntry)
+        );
+
+        String json = objectMapper.writeValueAsString(dto);
+        JsonNode node = objectMapper.readTree(json);
+
+        assertThat(node.get("entryTimestamp").asText()).isEqualTo("2024-01-01T10:15:30");
+        assertThat(node.get("exitTimestamp").asText()).isEqualTo("2024-01-02T11:45:00");
+        assertThat(node.get("intermediateEntries").get(0).get("tsUtc").asText())
+                .isEqualTo("2024-01-01T10:00:00+01:00");
+
+        TradeCompletedDTO restored = objectMapper.readValue(json, TradeCompletedDTO.class);
+
+        assertThat(restored).isEqualTo(dto);
+        assertThat(restored.pnlPct()).isEqualByComparingTo(new BigDecimal("1.2345"));
+        assertThat(restored.maxDrawdownPct()).isEqualByComparingTo(new BigDecimal("-2.5000"));
+        assertThat(restored.quantity()).isEqualByComparingTo(new BigDecimal("3.333"));
+    }
+
+    @Test
+    void candleDtoDeserializesOptionalFieldsAndKeepsPrecision() throws Exception {
+        String json = """
+                {
+                  "timeframe": "1D",
+                  "symbolFuture": "ES",
+                  "date": "2024-05-10T09:30:00",
+                  "open": 1.0000000001,
+                  "close": 2.50
+                }
+                """;
+
+        CandleDTO dto = objectMapper.readValue(json, CandleDTO.class);
+
+        assertThat(dto.getTimeframe()).isEqualTo("1D");
+        assertThat(dto.getSymbolFuture()).isEqualTo("ES");
+        assertThat(dto.getDate()).isEqualTo(LocalDateTime.of(2024, 5, 10, 9, 30));
+        assertThat(dto.getOpen()).isEqualByComparingTo(new BigDecimal("1.0000000001"));
+        assertThat(dto.getClose()).isEqualByComparingTo(new BigDecimal("2.50"));
+        assertThat(dto.getVolume()).isNull();
+        assertThat(dto.getVolumeAverage()).isNull();
+        assertThat(dto.getOpenInterest()).isNull();
+
+        String serialized = objectMapper.writeValueAsString(dto);
+        JsonNode node = objectMapper.readTree(serialized);
+
+        assertThat(node.get("date").asText()).isEqualTo("2024-05-10T09:30:00");
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure critical DTOs serialize/deserialize between JSON and Java without loss of information.  
- Force dates/offsets to use ISO-8601 textual representation for stable interchange.  
- Preserve numeric precision for `BigDecimal` fields and correctly handle optional fields during deserialization.  

### Description

- Add Jackson annotations to `TradeSignalDTO` (`@JsonCreator`, `@JsonProperty`, `@JsonFormat`) to support ISO timestamp serialization and reliable deserialization.  
- Annotate `TradeCompletedDTO` and `CandleDTO` timestamp/date fields with `@JsonFormat(shape = JsonFormat.Shape.STRING)` to enforce ISO-8601 string output.  
- Add `src/test/java/finance/project/api/model/DtoObjectMapperTest.java` which uses an `ObjectMapper` registered with `JavaTimeModule` and disables timestamp writing to validate round-trip JSON ↔ Java for `TradeSignalDTO`, `TradeCompletedDTO`, and `CandleDTO` and to check `BigDecimal` precision and optional fields.  

### Testing

- Added unit tests in `DtoObjectMapperTest` covering ISO timestamp serialization, `TradeCompletedDTO` round-trip with `IntermediateEntryDTO` `OffsetDateTime`, and `CandleDTO` precision/optional fields.  
- Attempted to run `./mvnw -q -Dtest=DtoObjectMapperTest test`, but execution failed due to a missing external dependency (`com.ib:tws-api-proto:jar:10.40`) in Maven Central, so the test run was aborted.  
- No automated test results are available from CI because of the dependency resolution error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e5404b888323a3478d4aa83a9dbe)