### PR TITLE
Add WireMock tests and resilient error handling to Coingecko client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,12 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<version>2.35.0</version>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- JavaFX -->
 		<!-- JavaFX Modules -->

--- a/src/main/java/finance/project/api/universe/client/CoingeckoUniverseClient.java
+++ b/src/main/java/finance/project/api/universe/client/CoingeckoUniverseClient.java
@@ -119,24 +119,29 @@ public class CoingeckoUniverseClient {
         headers.set("x-cg-demo-api-key", apiKey);
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<List<CoinMarket>> response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                entity,
-                new ParameterizedTypeReference<List<CoinMarket>>() {}
-        );
+        try {
+            ResponseEntity<List<CoinMarket>> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    new ParameterizedTypeReference<List<CoinMarket>>() {}
+            );
 
-        List<CoinMarket> markets = response.getBody();
-        if (markets == null || markets.isEmpty()) {
-            log.warn("[Coingecko] Empty response from coins/markets");
+            List<CoinMarket> markets = response.getBody();
+            if (markets == null || markets.isEmpty()) {
+                log.warn("[Coingecko] Empty response from coins/markets");
+                return List.of();
+            }
+
+            return markets.stream()
+                    .map(CoinMarket::symbol)
+                    .filter(sym -> sym != null && !sym.isBlank())
+                    .map(sym -> sym.toUpperCase(Locale.ROOT))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            log.warn("[Coingecko] Failed to fetch top crypto symbols (limit={})", limit, e);
             return List.of();
         }
-
-        return markets.stream()
-                .map(CoinMarket::symbol)
-                .filter(sym -> sym != null && !sym.isBlank())
-                .map(sym -> sym.toUpperCase(Locale.ROOT))
-                .collect(Collectors.toList());
     }
 
     public List<CoinCategory> listCategories() {
@@ -147,19 +152,24 @@ public class CoingeckoUniverseClient {
         headers.set("x-cg-demo-api-key", apiKey);
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<List<CoinCategory>> resp = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                entity,
-                new ParameterizedTypeReference<List<CoinCategory>>() {}
-        );
+        try {
+            ResponseEntity<List<CoinCategory>> resp = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    new ParameterizedTypeReference<List<CoinCategory>>() {}
+            );
 
-        List<CoinCategory> body = resp.getBody();
-        if (body == null || body.isEmpty()) {
-            log.warn("[Coingecko] Empty categories list");
+            List<CoinCategory> body = resp.getBody();
+            if (body == null || body.isEmpty()) {
+                log.warn("[Coingecko] Empty categories list");
+                return List.of();
+            }
+            return body;
+        } catch (Exception e) {
+            log.warn("[Coingecko] Failed to fetch coin categories", e);
             return List.of();
         }
-        return body;
     }
 
     /**
@@ -172,5 +182,4 @@ public class CoingeckoUniverseClient {
      */
     public record CoinCategory(String category_id, String name) {}
 }
-
 

--- a/src/test/java/finance/project/api/universe/client/CoingeckoUniverseClientWireMockTest.java
+++ b/src/test/java/finance/project/api/universe/client/CoingeckoUniverseClientWireMockTest.java
@@ -1,0 +1,83 @@
+package finance.project.api.universe.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+class CoingeckoUniverseClientWireMockTest {
+
+    private static final String API_KEY = "test-key";
+
+    @RegisterExtension
+    static WireMockExtension wireMock = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @Test
+    void fetchTopCryptoSymbols_returnsSymbolsFromWireMock() {
+        stubFor(get(urlPathEqualTo("/coins/markets"))
+                .withQueryParam("vs_currency", equalTo("usd"))
+                .withQueryParam("order", equalTo("market_cap_desc"))
+                .withQueryParam("per_page", equalTo("2"))
+                .withQueryParam("page", equalTo("1"))
+                .withQueryParam("sparkline", equalTo("false"))
+                .withHeader("x-cg-demo-api-key", equalTo(API_KEY))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withBody("""
+                                [
+                                  {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin"},
+                                  {"id": "ethereum", "symbol": "eth", "name": "Ethereum"}
+                                ]
+                                """)));
+
+        CoingeckoUniverseClient client = new CoingeckoUniverseClient(
+                wireMock.getRuntimeInfo().getHttpBaseUrl(),
+                API_KEY,
+                new RestTemplate()
+        );
+
+        List<String> symbols = client.fetchTopCryptoSymbols(2);
+
+        assertThat(symbols).containsExactly("BTC", "ETH");
+        verify(getRequestedFor(urlPathEqualTo("/coins/markets"))
+                .withHeader("x-cg-demo-api-key", equalTo(API_KEY)));
+    }
+
+    @Test
+    void fetchTopCryptoSymbols_returnsEmptyListOnTimeout() {
+        stubFor(get(urlPathEqualTo("/coins/markets"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                        .withFixedDelay(500)
+                        .withBody("[]")));
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(100);
+        requestFactory.setReadTimeout(100);
+
+        CoingeckoUniverseClient client = new CoingeckoUniverseClient(
+                wireMock.getRuntimeInfo().getHttpBaseUrl(),
+                API_KEY,
+                new RestTemplate(requestFactory)
+        );
+
+        List<String> symbols = client.fetchTopCryptoSymbols(1);
+
+        assertThat(symbols).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation

- Simulate the external Coingecko API in unit tests to validate nominal and failure flows.
- Ensure the Coingecko client gracefully handles network errors and timeouts instead of throwing exceptions.

### Description

- Add the `wiremock-jre8` test dependency to `pom.xml` for HTTP API simulation in tests.
- Harden `CoingeckoUniverseClient` by wrapping `fetchTopCryptoSymbols` and `listCategories` calls in `try/catch` blocks and returning empty lists on errors.
- Add `CoingeckoUniverseClientWireMockTest` which uses WireMock to validate a nominal response (returns `BTC`, `ETH`) and a timeout/error case (client returns an empty list) with a `RestTemplate` configured for short timeouts.

### Testing

- Ran `./mvnw -Dtest=CoingeckoUniverseClientWireMockTest test` to execute the new WireMock tests.
- The Maven run reported `BUILD FAILURE` because the dependency `com.ib:tws-api-proto:10.40` could not be resolved from Maven Central, which prevented the tests from running to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e544352083238c9bb9e9cce44d7b)