### PR TITLE
Add JaCoCo coverage checks for services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,50 @@
 		</resources>
 		<plugins>
 			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.12</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<includes>
+										<include>finance/project/api/services/**</include>
+									</includes>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.70</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>


### PR DESCRIPTION
### Motivation
- Enforce a minimum code coverage for service classes to improve code quality and catch untested logic early.
- Generate JaCoCo HTML reports for local inspection of coverage metrics.
- Fail the build when coverage for the services package falls below the configured threshold to prevent regressions.

### Description
- Added the `org.jacoco:jacoco-maven-plugin` (version `0.8.12`) to `pom.xml` with `prepare-agent`, `report`, and `check` executions bound to the `verify` phase.
- Configured a coverage rule that targets `finance/project/api/services/**` and requires a `LINE` `COVEREDRATIO` minimum of `0.70`.
- The `report` execution will generate the JaCoCo report during `mvn verify`, producing HTML output under the standard `target/site/jacoco` location.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e548af308323a827292a526db698)