### PR TITLE
Configure Surefire/Failsafe and rename integration tests to *IT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,37 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.java</include>
+					</includes>
+					<excludes>
+						<exclude>**/*IT.java</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.2.5</version>
+				<configuration>
+					<includes>
+						<include>**/*IT.java</include>
+					</includes>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.1</version>
 				<configuration>

--- a/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerIT.java
+++ b/src/test/java/finance/project/api/dataimport/api/DataImportJobControllerIT.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class DataImportJobControllerIntegrationTest extends AbstractMySqlIntegrationTest {
+class DataImportJobControllerIT extends AbstractMySqlIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/finance/project/api/dataimport/ingestion/BinanceHistoricalServiceIT.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/BinanceHistoricalServiceIT.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class BinanceHistoricalServiceIntegrationTest {
+class BinanceHistoricalServiceIT {
 
     @Autowired
     private BinanceHistoricalService binanceHistoricalService;

--- a/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionIT.java
+++ b/src/test/java/finance/project/api/repositories/CandleAvailabilityProjectionIT.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class CandleAvailabilityProjectionTest extends AbstractMySqlIntegrationTest {
+class CandleAvailabilityProjectionIT extends AbstractMySqlIntegrationTest {
 
     @Autowired
     private CandleRepository candleRepository;

--- a/src/test/java/finance/project/api/universe/UniverseRepositoryIT.java
+++ b/src/test/java/finance/project/api/universe/UniverseRepositoryIT.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class UniverseRepositoryTest extends AbstractMySqlIntegrationTest {
+class UniverseRepositoryIT extends AbstractMySqlIntegrationTest {
 
     @Autowired
     private UniverseRepository universeRepository;

--- a/src/test/java/finance/project/api/universe/api/UniverseControllerIT.java
+++ b/src/test/java/finance/project/api/universe/api/UniverseControllerIT.java
@@ -32,7 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class UniverseControllerIntegrationTest {
+class UniverseControllerIT {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
### Motivation
- Separate unit and integration test execution so `mvn test` runs unit tests only and `mvn verify` runs both unit and integration tests.
- Ensure integration tests are discoverable by Failsafe by adopting the `*IT` naming convention for existing integration tests.

### Description
- Added `maven-surefire-plugin` to `pom.xml` configured to include `**/*Test.java` and exclude `**/*IT.java`.
- Added `maven-failsafe-plugin` to `pom.xml` configured to include `**/*IT.java` and bound to the `integration-test` and `verify` goals.
- Renamed and updated test classes to the `*IT` convention (`DataImportJobControllerIntegrationTest` -> `DataImportJobControllerIT`, `BinanceHistoricalServiceIntegrationTest` -> `BinanceHistoricalServiceIT`, `CandleAvailabilityProjectionTest` -> `CandleAvailabilityProjectionIT`, `UniverseRepositoryTest` -> `UniverseRepositoryIT`, `UniverseControllerIntegrationTest` -> `UniverseControllerIT`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e549dc8483238f50aef91375b49d)