### PR TITLE
Fix crypto venue defaults for delta paths

### DIFF
--- a/src/main/java/finance/project/api/dataimport/DataImportService.java
+++ b/src/main/java/finance/project/api/dataimport/DataImportService.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -40,7 +41,7 @@ public class DataImportService {
         job.setSymbol(req.symbol());
         job.setTimeframe(req.timeframe());
         job.setAssetClass(req.assetClass());
-        job.setVenue(req.venue());
+        job.setVenue(resolveVenue(req));
         job.setCurrency(req.currency());
         job.setTimezone(req.timezone());
         job.setConflictPolicy(req.conflictPolicy());
@@ -63,5 +64,32 @@ public class DataImportService {
 
     public Optional<DataImportJob> getJob(String id) {
         return jobRepository.findById(id);
+    }
+
+    private String resolveVenue(DataImportRequest req) {
+        if (StringUtils.hasText(req.venue())) {
+            return req.venue();
+        }
+
+        String assetClass = req.assetClass();
+        if (assetClass != null && assetClass.toUpperCase().contains("CRYPTO")) {
+            return "SPOT";
+        }
+
+        String broker = req.broker();
+        if (broker != null && isCryptoBroker(broker)) {
+            return "SPOT";
+        }
+
+        return req.venue();
+    }
+
+    private boolean isCryptoBroker(String broker) {
+        String normalized = broker.trim().toUpperCase();
+        return normalized.equals("BINANCE")
+                || normalized.equals("OKX")
+                || normalized.equals("BYBIT")
+                || normalized.equals("MEXC")
+                || normalized.equals("BITGET");
     }
 }

--- a/src/main/java/finance/project/api/universe/service/UniverseImportRunner.java
+++ b/src/main/java/finance/project/api/universe/service/UniverseImportRunner.java
@@ -7,6 +7,7 @@ import finance.project.api.dataimport.dto.DataImportRequest;
 import finance.project.api.entities.Symbol;
 import finance.project.api.universe.Universe;
 import finance.project.api.universe.UniverseRepository;
+import finance.project.api.universe.UniverseType;
 import finance.project.api.universe.dto.UniverseImportRequest;
 import java.time.Instant;
 import java.util.LinkedHashSet;
@@ -63,9 +64,7 @@ public class UniverseImportRunner {
     }
 
     private DataImportRequest buildJobRequest(UniverseImportRequest request, Universe universe, Symbol symbol) {
-        String venue = (request.venue() != null && !request.venue().isBlank())
-                ? request.venue()
-                : symbol.getExchange();
+        String venue = resolveVenue(request, universe, symbol);
 
         String symbolForImport = symbol.getSymbol();
         String currency = symbol.getCurrency();
@@ -89,6 +88,29 @@ public class UniverseImportRunner {
                 null,
                 assetClass
         );
+    }
+
+    private String resolveVenue(UniverseImportRequest request, Universe universe, Symbol symbol) {
+        if (request.venue() != null && !request.venue().isBlank()) {
+            return request.venue();
+        }
+        if (universe.getType() == UniverseType.CRYPTO) {
+            return resolveCryptoVenue(symbol);
+        }
+        return symbol.getExchange();
+    }
+
+    private String resolveCryptoVenue(Symbol symbol) {
+        if (symbol != null && symbol.getMarket() != null) {
+            String normalized = symbol.getMarket().trim().toUpperCase(Locale.ROOT);
+            if (normalized.contains("FUTURE")) {
+                return "FUTURE";
+            }
+            if (normalized.contains("SPOT")) {
+                return "SPOT";
+            }
+        }
+        return "SPOT";
     }
 
     private boolean pauseBetweenJobs() {


### PR DESCRIPTION
### Motivation
- Prevent Delta Lake paths with a duplicated broker segment like `.../BINANCE/BINANCE/...` by fixing how the import `venue` is resolved.
- Ensure the data type (SPOT/FUTURE) appears between the exchange and currency in the path and default to `SPOT` when unspecified.
- Derive the correct crypto venue for universe imports from symbol metadata when available so FUTURE vs SPOT is respected.
- Preserve existing behavior for non-crypto asset classes and explicit `venue` requests.

### Description
- Added `resolveVenue(DataImportRequest)` to `DataImportService` and default to `SPOT` for crypto `assetClass` or known crypto brokers when `venue` is missing.
- Updated `UniverseImportRunner.buildJobRequest` to use a new `resolveVenue` helper and added `resolveCryptoVenue(Symbol)` which infers `SPOT`/`FUTURE` from `Symbol.getMarket()` and defaults to `SPOT`.
- Imported `StringUtils` and `UniverseType` where needed and kept explicit `venue` values unchanged.
- This change prevents the broker name from being used as the `venue` for crypto imports, producing paths like `.../CRYPTO/BINANCE/SPOT/USDT/ADA/` instead of `.../CRYPTO/BINANCE/BINANCE/USDT/ADA/`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b0c541e48323950fbe2bb3dd3629)