### PR TITLE
Add SPOT/FUTURE trading segment to IBKR Delta paths

### DIFF
--- a/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
+++ b/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
@@ -19,10 +19,23 @@ public class DeltaPathBuilder {
     public String buildPath(ResolvedInstrument instrument, String broker) {
         String market = sanitize(instrument != null ? instrument.marketTypeNormalized() : "UNKNOWN");
         String brokerSegment = sanitize(broker);
+        String tradingSegment = sanitize(resolveTradingSegment(instrument));
         String exchange = sanitize(instrument != null ? instrument.normalizedExchange() : "UNKNOWN");
         String currency = sanitize(instrument != null ? instrument.currency() : "UNKNOWN");
         String symbol = sanitize(instrument != null ? instrument.symbol() : "UNKNOWN");
-        return "%s/%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, brokerSegment, exchange, currency, symbol);
+        return "%s/%s/%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, brokerSegment, tradingSegment, exchange, currency, symbol);
+    }
+
+    private String resolveTradingSegment(ResolvedInstrument instrument) {
+        if (instrument == null) {
+            return "SPOT";
+        }
+        String marketType = StringUtils.trimWhitespace(instrument.marketTypeNormalized()).toUpperCase(Locale.ROOT);
+        String secType = StringUtils.trimWhitespace(instrument.secType()).toUpperCase(Locale.ROOT);
+        if (marketType.contains("FUT") || secType.contains("FUT")) {
+            return "FUTURE";
+        }
+        return "SPOT";
     }
 
     private String sanitize(String value) {


### PR DESCRIPTION
### Motivation
- Delta table paths for IBKR instruments lacked an explicit trading segment (`SPOT`/`FUTURE`) between broker and exchange causing inconsistent layout with other asset categories. 
- Crypto paths already include the trading segment and IBKR (equities/futures) paths should match that convention. 
- The goal is to ensure Delta paths like `.../IBKR/SPOT/NASDAQ/...` or `.../IBKR/FUTURE/CME/...` are produced for downstream consumers. 

### Description
- Updated `DeltaPathBuilder.buildPath` to include a trading segment in the returned path and switched the path template from six to seven segments. 
- Added `resolveTradingSegment(ResolvedInstrument)` which defaults to `SPOT` and returns `FUTURE` when the instrument's `marketTypeNormalized` or `secType` indicates futures. 
- Kept existing sanitization via `sanitize(...)` and reused `deltaLakeConfig.getBaseUri()` when formatting the new path. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957fa8ca60c83238af144ca134764dd)