### PR TITLE
Include SPOT/FUTURE trading segment in non-crypto Delta paths

### DIFF
--- a/src/main/java/finance/project/api/config/DeltaLakeConfig.java
+++ b/src/main/java/finance/project/api/config/DeltaLakeConfig.java
@@ -31,10 +31,29 @@ public class DeltaLakeConfig {
         String sanitizedCategory = sanitizeSegment(assetCategory);
         String sanitizedBroker = sanitizeSegment(broker);
         String sanitizedVenue = sanitizeSegment(venue);
+        String tradingSegment = resolveTradingSegment(assetCategory, venue);
         SymbolPathSegments segments = parseSymbolSegments(symbol);
 
-        return baseUri + "/" + sanitizedCategory + "/" + sanitizedBroker + "/" + sanitizedVenue + "/"
-                + segments.currency() + "/" + segments.baseSymbol() + "/";
+        if (isCryptoCategory(sanitizedCategory)) {
+            return baseUri + "/" + sanitizedCategory + "/" + sanitizedBroker + "/" + sanitizedVenue + "/"
+                    + segments.currency() + "/" + segments.baseSymbol() + "/";
+        }
+
+        return baseUri + "/" + sanitizedCategory + "/" + sanitizedBroker + "/" + tradingSegment + "/"
+                + sanitizedVenue + "/" + segments.currency() + "/" + segments.baseSymbol() + "/";
+    }
+
+    private String resolveTradingSegment(String assetCategory, String venue) {
+        String normalizedCategory = assetCategory == null ? "" : assetCategory.toUpperCase(Locale.ROOT);
+        String normalizedVenue = venue == null ? "" : venue.toUpperCase(Locale.ROOT);
+        if (normalizedCategory.contains("FUT") || normalizedVenue.contains("CME")) {
+            return "FUTURE";
+        }
+        return "SPOT";
+    }
+
+    private boolean isCryptoCategory(String category) {
+        return category != null && category.toUpperCase(Locale.ROOT).contains("CRYPTO");
     }
 
     private SymbolPathSegments parseSymbolSegments(String symbol) {

--- a/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
+++ b/src/main/java/finance/project/api/utils/DeltaPathBuilder.java
@@ -19,10 +19,23 @@ public class DeltaPathBuilder {
     public String buildPath(ResolvedInstrument instrument, String broker) {
         String market = sanitize(instrument != null ? instrument.marketTypeNormalized() : "UNKNOWN");
         String brokerSegment = sanitize(broker);
+        String tradingSegment = sanitize(resolveTradingSegment(instrument));
         String exchange = sanitize(instrument != null ? instrument.normalizedExchange() : "UNKNOWN");
         String currency = sanitize(instrument != null ? instrument.currency() : "UNKNOWN");
         String symbol = sanitize(instrument != null ? instrument.symbol() : "UNKNOWN");
-        return "%s/%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, brokerSegment, exchange, currency, symbol);
+        return "%s/%s/%s/%s/%s/%s/%s".formatted(deltaLakeConfig.getBaseUri(), market, brokerSegment, tradingSegment, exchange, currency, symbol);
+    }
+
+    private String resolveTradingSegment(ResolvedInstrument instrument) {
+        if (instrument == null) {
+            return "SPOT";
+        }
+        String marketType = StringUtils.trimWhitespace(instrument.marketTypeNormalized()).toUpperCase(Locale.ROOT);
+        String secType = StringUtils.trimWhitespace(instrument.secType()).toUpperCase(Locale.ROOT);
+        if (marketType.contains("FUT") || secType.contains("FUT")) {
+            return "FUTURE";
+        }
+        return "SPOT";
     }
 
     private String sanitize(String value) {

--- a/src/test/java/finance/project/api/config/DeltaLakeConfigTest.java
+++ b/src/test/java/finance/project/api/config/DeltaLakeConfigTest.java
@@ -19,14 +19,14 @@ class DeltaLakeConfigTest {
         String pathUnderscore = config.resolveTablePath("ACTION", "IBKR", "NYSE", "AAPL_EUR");
         String pathColon = config.resolveTablePath("ACTION", "IBKR", "NYSE", "AAPL:USD");
 
-        assertThat(pathUnderscore).isEqualTo("s3://datalake/ACTION/IBKR/NYSE/EUR/AAPL/");
-        assertThat(pathColon).isEqualTo("s3://datalake/ACTION/IBKR/NYSE/USD/AAPL/");
+        assertThat(pathUnderscore).isEqualTo("s3://datalake/ACTION/IBKR/SPOT/NYSE/EUR/AAPL/");
+        assertThat(pathColon).isEqualTo("s3://datalake/ACTION/IBKR/SPOT/NYSE/USD/AAPL/");
     }
 
     @Test
     void sanitizesSegmentsAndFallsBackToUnknownCurrencyWhenMissing() {
         String path = config.resolveTablePath(" Action  ", "  ", "  ", "  T TE @#  ");
 
-        assertThat(path).isEqualTo("s3://datalake/ACTION/UNKNOWN/UNKNOWN/UNKNOWN/T_TE___/");
+        assertThat(path).isEqualTo("s3://datalake/ACTION/UNKNOWN/SPOT/UNKNOWN/UNKNOWN/T_TE___/");
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure Delta table paths include an explicit trading segment (`SPOT`/`FUTURE`) for IBKR/non-crypto instruments to match the layout used for crypto and satisfy downstream expectations.
- Detect futures by asset category or venue/exchange and default to `SPOT` when not futures.
- Preserve existing crypto path layout so `CRYPTO` table paths remain unchanged.

### Description
- Insert a trading segment into the path generation by updating `DeltaLakeConfig.resolveTablePath` and `DeltaPathBuilder.buildPath` to use a seven-segment template instead of six.
- Add `resolveTradingSegment(...)` in `DeltaLakeConfig` and `DeltaPathBuilder` and an `isCryptoCategory(...)` helper to decide between `FUTURE` and `SPOT` and to keep crypto untouched.
- Keep existing sanitization behavior by reusing `sanitizeSegment`/`sanitize` and `baseUri` handling when formatting the new path.
- Modified files: `DeltaLakeConfig.java`, `DeltaPathBuilder.java`, and updated expectations in `DeltaLakeConfigTest.java`.

### Testing
- Updated unit test assertions in `DeltaLakeConfigTest` to expect the new `SPOT` segment for non-crypto paths and preserved the crypto test.
- No automated test suite or CI run was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957fa8ca60c83238af144ca134764dd)