### PR TITLE
Only auto-aggregate when source timeframe is 1min; add guards and tests

### DIFF
--- a/src/main/java/finance/project/api/dataimport/ingestion/BinanceHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/BinanceHistoricalService.java
@@ -64,6 +64,11 @@ public class BinanceHistoricalService {
         deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(validCandles, timeframe));
 
         String normalizedSource = normalizeTimeframe(timeframe);
+        if (!isOneMinuteTimeframe(normalizedSource)) {
+            log.info("[Binance] Auto-aggregation skipped for source timeframe {} (requires 1min)", timeframe);
+            return true;
+        }
+
         for (String target : TARGET_TIMEFRAMES) {
             if (target.equalsIgnoreCase(normalizedSource)) {
                 continue;
@@ -142,5 +147,13 @@ public class BinanceHistoricalService {
             case "1mo", "monthly" -> "monthly";
             default -> timeframe.toLowerCase();
         };
+    }
+
+    private boolean isOneMinuteTimeframe(String timeframe) {
+        if (timeframe == null) {
+            return false;
+        }
+        String normalized = timeframe.trim().toLowerCase();
+        return "1m".equals(normalized) || "1min".equals(normalized);
     }
 }

--- a/src/main/java/finance/project/api/dataimport/ingestion/BitgetHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/BitgetHistoricalService.java
@@ -50,6 +50,11 @@ public class BitgetHistoricalService {
         candleService.saveCandlesToDatabase(candles, symbol, timeframe);
         deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, timeframe));
 
+        if (!isOneMinuteTimeframe(timeframe)) {
+            log.info("[Bitget] Auto-aggregation skipped for source timeframe {} (requires 1min)", timeframe);
+            return true;
+        }
+
         try {
             List<CandleDTO> aggregated =
                     candleAggregationService.aggregateCandles(candles, timeframe, MarketType.CRYPTO);
@@ -79,5 +84,14 @@ public class BitgetHistoricalService {
             entities.add(candle);
         }
         return entities;
+    }
+
+
+    private boolean isOneMinuteTimeframe(String timeframe) {
+        if (timeframe == null) {
+            return false;
+        }
+        String normalized = timeframe.trim().toLowerCase();
+        return "1m".equals(normalized) || "1min".equals(normalized);
     }
 }

--- a/src/main/java/finance/project/api/dataimport/ingestion/BybitHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/BybitHistoricalService.java
@@ -50,6 +50,11 @@ public class BybitHistoricalService {
         candleService.saveCandlesToDatabase(candles, symbol, timeframe);
         deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, timeframe));
 
+        if (!isOneMinuteTimeframe(timeframe)) {
+            log.info("[Bybit] Auto-aggregation skipped for source timeframe {} (requires 1min)", timeframe);
+            return true;
+        }
+
         try {
             List<CandleDTO> aggregated =
                     candleAggregationService.aggregateCandles(candles, timeframe, MarketType.CRYPTO);
@@ -81,5 +86,14 @@ public class BybitHistoricalService {
             entities.add(candle);
         }
         return entities;
+    }
+
+
+    private boolean isOneMinuteTimeframe(String timeframe) {
+        if (timeframe == null) {
+            return false;
+        }
+        String normalized = timeframe.trim().toLowerCase();
+        return "1m".equals(normalized) || "1min".equals(normalized);
     }
 }

--- a/src/main/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportService.java
@@ -52,6 +52,11 @@ public class DatabentoCsvImportService {
         candleService.saveCandlesToDatabase(baseCandles, symbol, timeframe);
         deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(baseCandles, timeframe));
 
+        if (!isOneMinuteTimeframe(timeframe)) {
+            log.info("[Databento CSV] Auto-aggregation skipped for source timeframe {} (requires 1min)", timeframe);
+            return;
+        }
+
         for (String target : TARGET_TIMEFRAMES) {
             if (target.equalsIgnoreCase(timeframe)) {
                 continue;
@@ -98,5 +103,14 @@ public class DatabentoCsvImportService {
             return "data_unknown";
         }
         return "data_" + DATASET_FORMATTER.format(start);
+    }
+
+
+    private boolean isOneMinuteTimeframe(String timeframe) {
+        if (timeframe == null) {
+            return false;
+        }
+        String normalized = timeframe.trim().toLowerCase();
+        return "1m".equals(normalized) || "1min".equals(normalized);
     }
 }

--- a/src/main/java/finance/project/api/dataimport/ingestion/MexcHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/MexcHistoricalService.java
@@ -55,6 +55,11 @@ public class MexcHistoricalService {
 
         // Pas obligé de faire toutes les agrégations comme Binance au début,
         // mais si tu veux rester homogène :
+        if (!isOneMinuteTimeframe(timeframe)) {
+            log.info("[MEXC] Auto-aggregation skipped for source timeframe {} (requires 1min)", timeframe);
+            return true;
+        }
+
         try {
             List<CandleDTO> aggregated =
                     candleAggregationService.aggregateCandles(candles, timeframe, MarketType.CRYPTO);
@@ -84,5 +89,14 @@ public class MexcHistoricalService {
             entities.add(candle);
         }
         return entities;
+    }
+
+
+    private boolean isOneMinuteTimeframe(String timeframe) {
+        if (timeframe == null) {
+            return false;
+        }
+        String normalized = timeframe.trim().toLowerCase();
+        return "1m".equals(normalized) || "1min".equals(normalized);
     }
 }

--- a/src/main/java/finance/project/api/dataimport/ingestion/OkxHistoricalService.java
+++ b/src/main/java/finance/project/api/dataimport/ingestion/OkxHistoricalService.java
@@ -50,6 +50,11 @@ public class OkxHistoricalService {
         candleService.saveCandlesToDatabase(candles, symbol, timeframe);
         deltaLakeExporter.exportCandlesToDelta(job, mapForDelta(candles, timeframe));
 
+        if (!isOneMinuteTimeframe(timeframe)) {
+            log.info("[OKX] Auto-aggregation skipped for source timeframe {} (requires 1min)", timeframe);
+            return true;
+        }
+
         try {
             List<CandleDTO> aggregated =
                     candleAggregationService.aggregateCandles(candles, timeframe, MarketType.CRYPTO);
@@ -81,5 +86,14 @@ public class OkxHistoricalService {
             entities.add(candle);
         }
         return entities;
+    }
+
+
+    private boolean isOneMinuteTimeframe(String timeframe) {
+        if (timeframe == null) {
+            return false;
+        }
+        String normalized = timeframe.trim().toLowerCase();
+        return "1m".equals(normalized) || "1min".equals(normalized);
     }
 }

--- a/src/test/java/finance/project/api/dataimport/ingestion/BinanceHistoricalServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/BinanceHistoricalServiceTest.java
@@ -47,14 +47,14 @@ class BinanceHistoricalServiceTest {
     private BinanceHistoricalService service;
 
     @Test
-    void fetchAndSaveAggregatesAcrossMultipleTimeframes() {
-        DataImportJob job = job("BTCUSDT", "1h");
+    void fetchAndSaveAggregatesAcrossMultipleTimeframesWhenSourceIs1min() {
+        DataImportJob job = job("BTCUSDT", "1min");
         Instant start = Instant.parse("2024-01-01T00:00:00Z");
         Instant end = Instant.parse("2024-01-01T01:00:00Z");
         List<CandleDTO> baseCandles = List.of(candle(LocalDateTime.parse("2024-01-01T00:00:00")));
         List<CandleDTO> aggregatedCandles = List.of(candle(LocalDateTime.parse("2024-01-01T00:01:00")));
 
-        when(binanceService.getHistoricalCandlesInRange(eq("BTCUSDT"), eq("1h"), any(), any()))
+        when(binanceService.getHistoricalCandlesInRange(eq("BTCUSDT"), eq("1min"), any(), any()))
                 .thenReturn(baseCandles);
         when(candleAggregationService.aggregateCandles(eq(baseCandles), anyString(), eq(MarketType.CRYPTO)))
                 .thenReturn(aggregatedCandles);
@@ -62,14 +62,33 @@ class BinanceHistoricalServiceTest {
         boolean result = service.fetchAndSave(job, start, end);
 
         assertThat(result).isTrue();
-        verify(candleService).saveCandlesToDatabase(baseCandles, "BTCUSDT", "1h");
+        verify(candleService).saveCandlesToDatabase(baseCandles, "BTCUSDT", "1min");
         verify(deltaLakeExporter).exportCandlesToDelta(eq(job), anyList());
         verify(candleAggregationService, times(13))
                 .aggregateCandles(eq(baseCandles), anyString(), eq(MarketType.CRYPTO));
 
         ArgumentCaptor<String> timeframeCaptor = ArgumentCaptor.forClass(String.class);
         verify(candleService, times(13)).saveCandlesToDatabase(eq(aggregatedCandles), eq("BTCUSDT"), timeframeCaptor.capture());
-        assertThat(timeframeCaptor.getAllValues()).doesNotContain("1h");
+        assertThat(timeframeCaptor.getAllValues()).doesNotContain("1min");
+    }
+
+
+    @Test
+    void fetchAndSaveSkipsAutoAggregationWhenSourceIsNot1min() {
+        DataImportJob job = job("BTCUSDT", "1h");
+        Instant start = Instant.parse("2024-01-01T00:00:00Z");
+        Instant end = Instant.parse("2024-01-01T01:00:00Z");
+        List<CandleDTO> baseCandles = List.of(candle(LocalDateTime.parse("2024-01-01T00:00:00")));
+
+        when(binanceService.getHistoricalCandlesInRange(eq("BTCUSDT"), eq("1h"), any(), any()))
+                .thenReturn(baseCandles);
+
+        boolean result = service.fetchAndSave(job, start, end);
+
+        assertThat(result).isTrue();
+        verify(candleService).saveCandlesToDatabase(baseCandles, "BTCUSDT", "1h");
+        verify(deltaLakeExporter).exportCandlesToDelta(eq(job), anyList());
+        verify(candleAggregationService, never()).aggregateCandles(anyList(), anyString(), any());
     }
 
     @Test

--- a/src/test/java/finance/project/api/dataimport/ingestion/BitgetHistoricalServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/BitgetHistoricalServiceTest.java
@@ -45,25 +45,42 @@ class BitgetHistoricalServiceTest {
     private BitgetHistoricalService service;
 
     @Test
-    void fetchAndSavePersistsAndAggregates() {
+    void fetchAndSaveSkipsAutoAggregationWhenSourceIsNot1min() {
         DataImportJob job = job("BTCUSDT", "30m");
         Instant start = Instant.parse("2024-03-01T00:00:00Z");
         Instant end = Instant.parse("2024-03-01T02:00:00Z");
         List<CandleDTO> baseCandles = List.of(candle(LocalDateTime.parse("2024-03-01T00:00:00")));
-        List<CandleDTO> aggregatedCandles = List.of(candle(LocalDateTime.parse("2024-03-01T00:30:00")));
 
         when(bitgetService.getHistoricalCandlesInRange(eq("BTCUSDT"), eq("30m"), any(), any()))
                 .thenReturn(baseCandles);
-        when(candleAggregationService.aggregateCandles(eq(baseCandles), eq("30m"), eq(MarketType.CRYPTO)))
-                .thenReturn(aggregatedCandles);
-
         boolean result = service.fetchAndSave(job, start, end);
 
         assertThat(result).isTrue();
         verify(candleService).saveCandlesToDatabase(baseCandles, "BTCUSDT", "30m");
         verify(deltaLakeExporter).exportCandlesToDelta(eq(job), anyList());
-        verify(candleAggregationService).aggregateCandles(baseCandles, "30m", MarketType.CRYPTO);
-        verify(candleService).saveCandlesToDatabase(aggregatedCandles, "BTCUSDT", "30m");
+        verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
+    }
+
+    @Test
+    void fetchAndSaveAggregatesWhenSourceIs1min() {
+        DataImportJob job = job("BTCUSDT", "1min");
+        Instant start = Instant.parse("2024-03-01T00:00:00Z");
+        Instant end = Instant.parse("2024-03-01T02:00:00Z");
+        List<CandleDTO> baseCandles = List.of(candle(LocalDateTime.parse("2024-03-01T00:00:00")));
+        List<CandleDTO> aggregatedCandles = List.of(candle(LocalDateTime.parse("2024-03-01T00:01:00")));
+
+        when(bitgetService.getHistoricalCandlesInRange(eq("BTCUSDT"), eq("1min"), any(), any()))
+                .thenReturn(baseCandles);
+        when(candleAggregationService.aggregateCandles(eq(baseCandles), eq("1min"), eq(MarketType.CRYPTO)))
+                .thenReturn(aggregatedCandles);
+
+        boolean result = service.fetchAndSave(job, start, end);
+
+        assertThat(result).isTrue();
+        verify(candleService).saveCandlesToDatabase(baseCandles, "BTCUSDT", "1min");
+        verify(deltaLakeExporter).exportCandlesToDelta(eq(job), anyList());
+        verify(candleAggregationService).aggregateCandles(baseCandles, "1min", MarketType.CRYPTO);
+        verify(candleService).saveCandlesToDatabase(aggregatedCandles, "BTCUSDT", "1min");
     }
 
     @Test

--- a/src/test/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/DatabentoCsvImportServiceTest.java
@@ -89,6 +89,23 @@ class DatabentoCsvImportServiceTest {
         assertThat(timeframeCaptor.getAllValues()).contains("monthly");
     }
 
+
+    @Test
+    void importCsvSkipsAutoAggregationWhenSourceIsNot1min() {
+        DataImportJob job = job("ES", "1h");
+        Instant start = Instant.parse("2024-02-01T00:00:00Z");
+        Instant end = Instant.parse("2024-02-02T00:00:00Z");
+        List<CandleDTO> baseCandles = List.of(candle(LocalDateTime.parse("2024-02-01T00:00:00")));
+
+        when(candleService.loadCsvCME("ES", "1h", "data_2024-02")).thenReturn(baseCandles);
+
+        service.importCsv(job, start, end, null);
+
+        verify(candleService).saveCandlesToDatabase(baseCandles, "ES", "1h");
+        verify(deltaLakeExporter).exportCandlesToDelta(eq(job), anyList());
+        verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
+    }
+
     @Test
     void importCsvSkipsWhenNoCandles() {
         DataImportJob job = job("ES", "1min");

--- a/src/test/java/finance/project/api/dataimport/ingestion/MexcHistoricalServiceTest.java
+++ b/src/test/java/finance/project/api/dataimport/ingestion/MexcHistoricalServiceTest.java
@@ -45,25 +45,42 @@ class MexcHistoricalServiceTest {
     private MexcHistoricalService service;
 
     @Test
-    void fetchAndSavePersistsAndAggregates() {
+    void fetchAndSaveSkipsAutoAggregationWhenSourceIsNot1min() {
         DataImportJob job = job("ETHUSDT", "15m");
         Instant start = Instant.parse("2024-02-01T00:00:00Z");
         Instant end = Instant.parse("2024-02-01T02:00:00Z");
         List<CandleDTO> baseCandles = List.of(candle(LocalDateTime.parse("2024-02-01T00:00:00")));
-        List<CandleDTO> aggregatedCandles = List.of(candle(LocalDateTime.parse("2024-02-01T00:15:00")));
 
         when(mexcService.getHistoricalCandlesInRange(eq("ETHUSDT"), eq("15m"), any(), any()))
                 .thenReturn(baseCandles);
-        when(candleAggregationService.aggregateCandles(eq(baseCandles), eq("15m"), eq(MarketType.CRYPTO)))
-                .thenReturn(aggregatedCandles);
-
         boolean result = service.fetchAndSave(job, start, end);
 
         assertThat(result).isTrue();
         verify(candleService).saveCandlesToDatabase(baseCandles, "ETHUSDT", "15m");
         verify(deltaLakeExporter).exportCandlesToDelta(eq(job), anyList());
-        verify(candleAggregationService).aggregateCandles(baseCandles, "15m", MarketType.CRYPTO);
-        verify(candleService).saveCandlesToDatabase(aggregatedCandles, "ETHUSDT", "15m");
+        verify(candleAggregationService, never()).aggregateCandles(anyList(), any(), any());
+    }
+
+    @Test
+    void fetchAndSaveAggregatesWhenSourceIs1min() {
+        DataImportJob job = job("ETHUSDT", "1min");
+        Instant start = Instant.parse("2024-02-01T00:00:00Z");
+        Instant end = Instant.parse("2024-02-01T02:00:00Z");
+        List<CandleDTO> baseCandles = List.of(candle(LocalDateTime.parse("2024-02-01T00:00:00")));
+        List<CandleDTO> aggregatedCandles = List.of(candle(LocalDateTime.parse("2024-02-01T00:01:00")));
+
+        when(mexcService.getHistoricalCandlesInRange(eq("ETHUSDT"), eq("1min"), any(), any()))
+                .thenReturn(baseCandles);
+        when(candleAggregationService.aggregateCandles(eq(baseCandles), eq("1min"), eq(MarketType.CRYPTO)))
+                .thenReturn(aggregatedCandles);
+
+        boolean result = service.fetchAndSave(job, start, end);
+
+        assertThat(result).isTrue();
+        verify(candleService).saveCandlesToDatabase(baseCandles, "ETHUSDT", "1min");
+        verify(deltaLakeExporter).exportCandlesToDelta(eq(job), anyList());
+        verify(candleAggregationService).aggregateCandles(baseCandles, "1min", MarketType.CRYPTO);
+        verify(candleService).saveCandlesToDatabase(aggregatedCandles, "ETHUSDT", "1min");
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Prevent automatic aggregation from running when the imported source candles are not 1-minute granularity to avoid incorrect or duplicate rollups.
- Make behavior explicit and consistent across CSV (Databento/CME) and multiple exchange historical import services (Binance, Bitget, Bybit, MEXC, OKX).

### Description
- Added an `isOneMinuteTimeframe` helper and an early-return guard with an informational log to `BinanceHistoricalService`, `BitgetHistoricalService`, `BybitHistoricalService`, `MexcHistoricalService`, `OkxHistoricalService`, and `DatabentoCsvImportService` to skip auto-aggregation unless the source timeframe is `1m`/`1min`.
- Adjusted Binance to normalize the source timeframe and skip auto-aggregation unless source is 1 minute, preserving the existing aggregation loop for valid cases.
- Updated unit tests in `BinanceHistoricalServiceTest`, `BitgetHistoricalServiceTest`, `DatabentoCsvImportServiceTest`, and `MexcHistoricalServiceTest` to cover both behaviors (skip when not 1min and aggregate when 1min) and to reflect the normalized timeframe strings used in mocks and verifications.

### Testing
- Ran updated unit tests under `src/test/java/finance/project/api/dataimport/ingestion/` including `BinanceHistoricalServiceTest`, `BitgetHistoricalServiceTest`, `DatabentoCsvImportServiceTest`, and `MexcHistoricalServiceTest` which now include cases for skipping aggregation and for aggregating when source is `1min`. 
- All modified and existing unit tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b398038883239f8632d83924dced)